### PR TITLE
Fix lost task IDs when task data is missing

### DIFF
--- a/jobbers/models/task.py
+++ b/jobbers/models/task.py
@@ -6,6 +6,7 @@ from collections.abc import AsyncGenerator, Awaitable
 from enum import StrEnum
 from typing import Any, Self, cast
 
+from opentelemetry import metrics
 from pydantic import BaseModel, Field
 from redis.asyncio.client import Pipeline, Redis
 from ulid import ULID
@@ -22,6 +23,8 @@ from .task_config import TaskConfig
 from .task_status import TaskStatus
 
 logger = logging.getLogger(__name__)
+meter = metrics.get_meter(__name__)
+tasks_missing_data = meter.create_counter("tasks_missing_data", unit="1")
 
 class Task(BaseModel):
     """A task to be executed."""
@@ -199,6 +202,7 @@ class TaskAdapter:
     HEARTBEAT_SCORES = "task-heartbeats:{queue}".format
     TASK_BY_TYPE_IDX = "task-type-idx:{name}".format
     QUEUE_RATE_LIMITER = "rate-limiter:{queue}".format
+    DLQ_MISSING_DATA = "dlq-missing-data"
 
     # Atomically enqueue a new task (no rate limiting).
     # Skips the ZADD if the task details key already exists (idempotent re-submit guard).
@@ -421,14 +425,20 @@ class TaskAdapter:
         # see https://redis.io/docs/latest/commands/blpop/#what-key-is-served-first-what-client-what-element-priority-ordering-details
         # for details of how the order of keys impact how tasks are popped
         task_queues = {self.TASKS_BY_QUEUE(queue=queue) for queue in queues}
-        task_id = await self.data_store.bzpopmin(task_queues, timeout=pop_timeout)
-        if task_id:
-            task = await self.get_task(ULID.from_bytes(task_id[1]))
+        pop_result = await self.data_store.bzpopmin(task_queues, timeout=pop_timeout)
+        while pop_result:
+            task = await self.get_task(ULID.from_bytes(pop_result[1]))
             if task:
                 return task
-            logger.warning("Task with ID %s not found.", task_id)
-        else:
-            logger.info("task query timed out")
+            # Task ID was popped from the queue but its data is missing.
+            # Record a metric, move the bare ID to the missing-data DLQ for
+            # investigation, and keep waiting for a valid task.
+            logger.error("Task %s popped from queue but data not found; adding to %s", pop_result[1], self.DLQ_MISSING_DATA)
+            tasks_missing_data.add(1)
+            now = dt.datetime.now(dt.UTC)
+            await self.data_store.zadd(self.DLQ_MISSING_DATA, {pop_result[1]: now.timestamp()})
+            pop_result = await self.data_store.bzpopmin(task_queues, timeout=pop_timeout)
+        logger.info("task query timed out")
         return None
 
     async def clean_terminal_tasks(self, now: dt.datetime, max_age: dt.timedelta) -> None:

--- a/tests/test_state_manager.py
+++ b/tests/test_state_manager.py
@@ -83,13 +83,35 @@ async def test_get_next_task_no_task_found(real_state_manager):
 
 @pytest.mark.asyncio
 async def test_get_next_task_missing_task_data(real_redis, real_state_manager):
-    """Test that get_next_task logs a warning and returns None if task data is missing."""
+    """Test that a task with missing data is moved to dlq-missing-data and None is returned."""
     task_id = ULID()
     await real_redis.zadd("task-queues:queue1", {task_id.bytes: 1})
 
     task = await real_state_manager.get_next_task(["queue1", "queue2"], pop_timeout=1)
 
     assert task is None
+    dlq_members = await real_redis.zrange("dlq-missing-data", 0, -1)
+    assert task_id.bytes in dlq_members
+
+
+@pytest.mark.asyncio
+async def test_get_next_task_skips_missing_data_and_returns_valid(real_redis, real_state_manager):
+    """When the first queued task has missing data it is skipped and the next valid task is returned."""
+    missing_id = ULID()
+    valid_id = ULID()
+    valid_task = Task(id=valid_id, name="Test Task", queue="queue1", version=1,
+                      status=TaskStatus.SUBMITTED, submitted_at=FROZEN_TIME)
+
+    # missing_id has a lower score so it is popped first
+    await real_redis.zadd("task-queues:queue1", {missing_id.bytes: 1, valid_id.bytes: 2})
+    await real_redis.set(f"task:{valid_id}", valid_task.pack())
+
+    task = await real_state_manager.get_next_task(["queue1"], pop_timeout=1)
+
+    assert task is not None
+    assert task.id == valid_id
+    dlq_members = await real_redis.zrange("dlq-missing-data", 0, -1)
+    assert missing_id.bytes in dlq_members
 
 @pytest.fixture
 def rate_limiter(state_manager):


### PR DESCRIPTION
## Summary

Fixes #20.

- **Loop instead of return on missing data**: `TaskAdapter.get_next_task()` now loops when a task ID is popped from the queue but its data key (`task:{id}`) is absent, rather than returning `None` and letting the worker generator stop with `StopAsyncIteration`.
- **Missing-data DLQ**: Each orphaned task ID is written to the `dlq-missing-data` sorted set (score = current timestamp) so operators can inspect and investigate data-loss events.
- **Metric**: A `tasks_missing_data` counter is incremented for every missing-data event, enabling alerting.

## Test plan

- [x] `test_get_next_task_missing_task_data` — updated to assert the task ID lands in `dlq-missing-data` (previously only checked `task is None`)
- [x] `test_get_next_task_skips_missing_data_and_returns_valid` — new test: when the first queued task has missing data, it is skipped and the next valid task is returned instead of the worker stopping
- [x] Full test suite passes (267 tests)
- [x] `mypy` strict — no issues
- [x] `ruff` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)