### PR TITLE
RFC: Airflow integration via JobbersExecutor

### DIFF
--- a/airflow_jobbers/__init__.py
+++ b/airflow_jobbers/__init__.py
@@ -1,0 +1,1 @@
+"""airflow-jobbers: Apache Airflow executor backed by the Jobbers task framework."""

--- a/airflow_jobbers/executor.py
+++ b/airflow_jobbers/executor.py
@@ -1,0 +1,132 @@
+"""Airflow executor that runs tasks via the Jobbers task execution framework.
+
+Configure Airflow to use this executor by setting in ``airflow.cfg``::
+
+    [core]
+    executor = airflow_jobbers.executor.JobbersExecutor
+
+Environment variables
+---------------------
+JOBBERS_MANAGER_URL
+    Base URL of the Jobbers Manager API (default: ``http://localhost:8000``).
+JOBBERS_QUEUE
+    Name of the Jobbers queue to submit Airflow tasks to (default: ``airflow``).
+    Individual DAG tasks can override this via their ``queue`` attribute.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import TYPE_CHECKING, Any
+
+import httpx
+from ulid import ULID
+
+from airflow.executors.base_executor import BaseExecutor
+
+if TYPE_CHECKING:
+    from airflow.models.taskinstance import TaskInstanceKey
+
+logger = logging.getLogger(__name__)
+
+_AIRFLOW_TASK_NAME = "airflow_task_runner"
+_AIRFLOW_TASK_VERSION = 1
+
+# Jobbers status values that map to Airflow terminal states
+_SUCCESS_STATUSES = frozenset({"completed"})
+_FAILURE_STATUSES = frozenset({"failed", "stalled", "dropped", "cancelled"})
+
+
+class JobbersExecutor(BaseExecutor):
+    """Airflow executor that submits tasks to the Jobbers task execution framework.
+
+    Each Airflow task instance is submitted to the Jobbers Manager API as an
+    ``airflow_task_runner`` task.  Jobbers workers run the task by executing
+    the Airflow CLI command supplied by the scheduler.
+
+    The Jobbers worker must have ``jobbers.airflow_task`` loaded, e.g.::
+
+        jobbers_worker jobbers.airflow_task
+    """
+
+    def __init__(self, parallelism: int = 0) -> None:
+        super().__init__(parallelism=parallelism)
+        self._manager_url: str = os.environ.get("JOBBERS_MANAGER_URL", "http://localhost:8000")
+        self._queue: str = os.environ.get("JOBBERS_QUEUE", "airflow")
+        # Maps Airflow TaskInstanceKey → Jobbers task_id (ULID string)
+        self._key_to_task_id: dict[TaskInstanceKey, str] = {}
+
+    def start(self) -> None:
+        logger.info(
+            "JobbersExecutor started (manager=%s, queue=%s)",
+            self._manager_url,
+            self._queue,
+        )
+
+    def execute_async(
+        self,
+        key: TaskInstanceKey,
+        command: list[str],
+        queue: str | None = None,
+        executor_config: Any = None,
+    ) -> None:
+        """Submit an Airflow task instance to Jobbers.
+
+        The *command* is the Airflow CLI invocation the scheduler wants to run,
+        e.g. ``["airflow", "tasks", "run", dag_id, task_id, run_id]``.
+        """
+        task_id = str(ULID())
+        target_queue = queue or self._queue
+        payload = {
+            "id": task_id,
+            "name": _AIRFLOW_TASK_NAME,
+            "version": _AIRFLOW_TASK_VERSION,
+            "queue": target_queue,
+            "parameters": {
+                "command": command,
+                "jobbers_task_id": task_id,
+            },
+        }
+        try:
+            with httpx.Client() as client:
+                resp = client.post(f"{self._manager_url}/submit-task", json=payload)
+                resp.raise_for_status()
+            self._key_to_task_id[key] = task_id
+            logger.info("Submitted Airflow task %s as Jobbers task %s", key, task_id)
+        except httpx.HTTPError:
+            logger.exception("Failed to submit task %s to Jobbers", key)
+            self.fail(key)
+
+    def sync(self) -> None:
+        """Poll Jobbers for task status and update Airflow task states."""
+        if not self._key_to_task_id:
+            return
+
+        task_ids = list(self._key_to_task_id.values())
+        try:
+            with httpx.Client() as client:
+                resp = client.post(
+                    f"{self._manager_url}/task-status/bulk",
+                    json={"task_ids": task_ids},
+                )
+                resp.raise_for_status()
+                statuses: dict[str, str] = resp.json()["statuses"]
+        except httpx.HTTPError:
+            logger.exception("Failed to poll task statuses from Jobbers")
+            return
+
+        for key, task_id in list(self._key_to_task_id.items()):
+            status = statuses.get(task_id)
+            if status in _SUCCESS_STATUSES:
+                self.success(key)
+                del self._key_to_task_id[key]
+            elif status in _FAILURE_STATUSES:
+                self.fail(key)
+                del self._key_to_task_id[key]
+
+    def end(self) -> None:
+        logger.info("JobbersExecutor shutting down")
+
+    def terminate(self) -> None:
+        logger.info("JobbersExecutor terminated")

--- a/airflow_jobbers/pyproject.toml
+++ b/airflow_jobbers/pyproject.toml
@@ -1,0 +1,23 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "airflow-jobbers"
+version = "0.0.1"
+description = "Apache Airflow executor backed by the Jobbers task execution framework"
+requires-python = ">=3.11"
+authors = [
+    { name = "Josh Forman", email = "josh@yoshrote.com" },
+]
+dependencies = [
+    "apache-airflow>=2.6",
+    "httpx",
+    "python-ulid",
+]
+
+[project.urls]
+Homepage = "https://github.com/yoshrote/jobbers"
+
+[tool.hatch.build.targets.wheel]
+packages = ["airflow_jobbers"]

--- a/docs/airflow-integration.md
+++ b/docs/airflow-integration.md
@@ -1,0 +1,68 @@
+# Airflow + Jobbers Integration: Design Proposal
+
+## Context
+
+Apache Airflow uses an **executor** abstraction to decouple DAG/task orchestration from actual task execution. The CeleryExecutor sends tasks to Celery queues; workers execute them and report status back. The goal is to replace this Celery layer with Jobbers while keeping Airflow responsible for DAG definition, dependency resolution, scheduling, and the UI.
+
+## Integration Model: Jobbers as an Airflow Executor
+
+Airflow's division of responsibility is:
+
+| Airflow responsibility (unchanged) | Jobbers responsibility (new) |
+|------------------------------------|------------------------------|
+| DAG definitions (Python files)     | Distributed task execution   |
+| Task dependency resolution         | Stall detection via heartbeats |
+| Scheduler (decides what runs next) | Retry logic with backoff     |
+| Metadata DB, XCom, UI             | Cancellation, DLQ           |
+| Connections/Variables/config       | Concurrency control          |
+
+This is viable because Airflow's executor is a well-defined plugin interface, and CeleryExecutor is a clear reference implementation.
+
+## What Needs to Be Built
+
+### 1. A `JobbersExecutor` Airflow plugin (new library, e.g. `airflow-jobbers`)
+
+Implements `BaseExecutor` with:
+- `execute_async()`: Submits a task to the Jobbers Manager API (`POST /submit-task`)
+- `sync()`: Polls Jobbers for status changes and reports back to Airflow's scheduler
+- State mapping: Jobbers statuses → Airflow `TaskInstanceState`
+- Configuration: Jobbers manager URL, queue name, auth
+
+### 2. A built-in Airflow runner task in Jobbers
+
+A registered `@register_task` function that:
+- Receives an Airflow task instance descriptor as parameters (dag_id, task_id, run_id, etc.)
+- Executes it via `airflow tasks run <dag_id> <task_id> <run_id>` (subprocess) or direct Python invocation
+- Reports heartbeats during long-running operators
+- Returns success/failure in a format the executor can map
+
+This is the bridge between "Jobbers task" and "Airflow operator execution."
+
+### 3. Possibly a bulk status endpoint on the Jobbers Manager
+
+The executor may need to poll many task states simultaneously. A `POST /task-status/bulk` endpoint would be more efficient than N individual calls. The existing endpoint structure makes this straightforward to add.
+
+## Key Gaps in Jobbers to Address
+
+| Gap | Severity | Notes |
+|-----|----------|-------|
+| No bulk status query | Low | Easy to add; executor polling scales linearly without it |
+| Synchronous operator support | Low | Airflow operators are sync; Jobbers workers can run them via `asyncio.to_thread()` |
+| No webhook/callback | Low | Polling works; Celery also polls |
+| Worker environment | Medium | Jobbers workers need Airflow installed + DAG file access (same requirement as CeleryExecutor workers) |
+| State mapping | Low | Straightforward: COMPLETED→SUCCESS, FAILED/STALLED→FAILED, CANCELLED→REMOVED |
+
+## Why This Is Viable
+
+- Airflow's executor interface is stable and designed for this kind of replacement
+- Jobbers already has submission, status tracking, cancellation, and retry infrastructure
+- The CeleryExecutor is ~600 lines; a JobbersExecutor would be comparable in scope
+- Jobbers adds value over Celery: better stall detection, structured retry policies, cancellation, and DLQ
+
+## Rough Scope
+
+Two deliverables:
+1. **Jobbers changes**: built-in Airflow runner task + optional bulk status endpoint
+2. **New `airflow-jobbers` package**: `JobbersExecutor` class + state mapping + config
+
+No changes to Airflow's core are needed — this is entirely an executor plugin.

--- a/jobbers/airflow_task.py
+++ b/jobbers/airflow_task.py
@@ -1,0 +1,89 @@
+"""
+Built-in Jobbers task that executes an Apache Airflow task instance.
+
+Workers that need to serve as Airflow executor backends should load this module
+so that the ``airflow_task_runner`` task is registered:
+
+    jobbers_worker jobbers.airflow_task
+
+The ``airflow_task_runner`` task receives a CLI ``command`` (the same list of
+strings that Airflow's CeleryExecutor would pass to a Celery worker) and runs
+it as a subprocess.  It sends periodic heartbeats back to Jobbers while the
+subprocess is running so the cleaner does not mark the task as stalled.
+"""
+
+import asyncio
+import datetime as dt
+import logging
+from asyncio.subprocess import PIPE
+from typing import Any
+
+from jobbers.models.task_config import DeadLetterPolicy
+from jobbers.registry import register_task
+
+logger = logging.getLogger(__name__)
+
+_HEARTBEAT_INTERVAL = 30  # seconds between heartbeat updates
+
+
+@register_task(
+    name="airflow_task_runner",
+    version=1,
+    timeout=None,            # Airflow manages its own task timeouts
+    max_retries=0,           # Airflow manages retries; we never retry here
+    max_heartbeat_interval=dt.timedelta(seconds=90),
+    dead_letter_policy=DeadLetterPolicy.SAVE,
+)
+async def run_airflow_task(command: list[str], jobbers_task_id: str) -> dict[str, Any]:
+    """
+    Execute an Airflow task instance by running its CLI command as a subprocess.
+
+    Args:
+        command: The Airflow CLI command to run, e.g.
+            ``["airflow", "tasks", "run", dag_id, task_id, run_id]``.
+        jobbers_task_id: The ULID string of this Jobbers task instance, used to
+            send heartbeats while the subprocess is running.
+
+    Returns:
+        A dict with ``returncode`` and ``stdout`` from the subprocess.
+
+    Raises:
+        RuntimeError: If the subprocess exits with a non-zero return code.
+    """
+    from ulid import ULID
+
+    from jobbers.db import get_client
+    from jobbers.models.task import TaskAdapter
+
+    task_id = ULID.from_str(jobbers_task_id)
+    adapter = TaskAdapter(get_client())
+
+    logger.info("Running Airflow command: %s", command)
+    proc = await asyncio.create_subprocess_exec(*command, stdout=PIPE, stderr=PIPE)
+
+    async def _heartbeat_loop() -> None:
+        while True:
+            await asyncio.sleep(_HEARTBEAT_INTERVAL)
+            task = await adapter.get_task(task_id)
+            if task:
+                await task.heartbeat()
+
+    heartbeat_task = asyncio.create_task(_heartbeat_loop())
+    try:
+        stdout, stderr = await proc.communicate()
+    finally:
+        heartbeat_task.cancel()
+        try:
+            await heartbeat_task
+        except asyncio.CancelledError:
+            pass
+
+    if proc.returncode != 0:
+        stderr_text = stderr.decode(errors="replace")
+        logger.error("Airflow task failed (returncode=%s): %s", proc.returncode, stderr_text)
+        raise RuntimeError(stderr_text)
+
+    return {
+        "returncode": proc.returncode,
+        "stdout": stdout.decode(errors="replace"),
+    }

--- a/jobbers/models/task.py
+++ b/jobbers/models/task.py
@@ -4,7 +4,7 @@ import logging
 from asyncio import TaskGroup
 from collections.abc import AsyncGenerator, Awaitable
 from enum import StrEnum
-from typing import Any, Self, cast
+from typing import Any, Self, cast, get_origin
 
 from opentelemetry import metrics
 from pydantic import BaseModel, Field
@@ -55,7 +55,12 @@ class Task(BaseModel):
         signature = inspect.get_annotations(self.task_config.function)
         for param, psig in signature.items():
             # Skip the return type annotation
-            if param != "return" and not isinstance(self.parameters[param], psig):
+            if param == "return":
+                continue
+            # get_origin handles generic aliases (e.g. list[str] → list) so that
+            # isinstance() works correctly; falls back to psig for plain types.
+            check_type = get_origin(psig) or psig
+            if not isinstance(self.parameters[param], check_type):
                 return False
         return True
 

--- a/jobbers/task_routes.py
+++ b/jobbers/task_routes.py
@@ -279,6 +279,35 @@ async def resubmit_from_dlq(request: DLQResubmitRequest) -> dict[str, Any]:
     }
 
 
+class BulkStatusRequest(BaseModel):
+    """Request body for bulk task status query."""
+
+    task_ids: list[str] = Field(description="List of task IDs to check status for.")
+
+
+@app.post("/task-status/bulk")
+async def get_bulk_task_status(request: BulkStatusRequest) -> dict[str, Any]:
+    """
+    Retrieve the status of multiple tasks in a single request.
+
+    Returns a mapping of task_id → status string. Tasks not found return ``"unknown"``.
+    Useful for executors that need to poll many tasks without N individual round-trips.
+    """
+    adapter = TaskAdapter(db.get_client())
+
+    async def _fetch_one(task_id_str: str) -> tuple[str, str]:
+        try:
+            task_uid = ULID.from_str(task_id_str)
+            task = await adapter.get_task(task_uid)
+            return task_id_str, str(task.status) if task else "unknown"
+        except Exception:
+            logger.exception("Error fetching status for task %s", task_id_str)
+            return task_id_str, "unknown"
+
+    pairs = await asyncio.gather(*(_fetch_one(tid) for tid in request.task_ids))
+    return {"statuses": dict(pairs)}
+
+
 @app.get("/active-tasks")
 async def get_active_tasks(queue: str | None = None) -> dict[str, Any]:
     """Retrieve tasks currently being executed (those with an active heartbeat record)."""


### PR DESCRIPTION
Addresses #28 
## Context

Apache Airflow uses an **executor** abstraction to decouple DAG/task orchestration from actual task execution. The CeleryExecutor sends tasks to Celery queues; workers execute them and report status back. The goal is to replace this Celery layer with Jobbers while keeping Airflow responsible for DAG definition, dependency resolution, scheduling, and the UI.

## Integration Model: Jobbers as an Airflow Executor

| Airflow responsibility (unchanged) | Jobbers responsibility (new) |
|------------------------------------|------------------------------|
| DAG definitions (Python files)     | Distributed task execution   |
| Task dependency resolution         | Stall detection via heartbeats |
| Scheduler (decides what runs next) | Retry logic with backoff     |
| Metadata DB, XCom, UI             | Cancellation, DLQ           |
| Connections/Variables/config       | Concurrency control          |

## What Needs to Be Built

### 1. `JobbersExecutor` Airflow plugin (new `airflow-jobbers` package)

Implements `BaseExecutor` with:
- `execute_async()`: Submits a task to the Jobbers Manager API (`POST /submit-task`)
- `sync()`: Polls Jobbers for status changes and reports back to Airflow's scheduler
- State mapping: Jobbers statuses → Airflow `TaskInstanceState`

### 2. Built-in Airflow runner task in Jobbers

A `@register_task` function that receives an Airflow task instance descriptor (dag_id, task_id, run_id) and executes it via `airflow tasks run` — the same mechanism CeleryExecutor workers use. This is the bridge between the two systems.

### 3. Optional: bulk status endpoint on the Manager

`POST /task-status/bulk` so the executor can poll many task states in one call rather than N individual requests.

## Key Gaps

| Gap | Severity | Notes |
|-----|----------|-------|
| No bulk status query | Low | Easy to add; executor polling scales linearly without it |
| Synchronous operator support | Low | Airflow operators are sync; `asyncio.to_thread()` handles this |
| No webhook/callback | Low | Polling works; CeleryExecutor also polls |
| Worker environment | Medium | Workers need Airflow installed + DAG file access (same as CeleryExecutor) |
| State mapping | Low | COMPLETED→SUCCESS, FAILED/STALLED→FAILED, CANCELLED→REMOVED |

## Why This Is Viable

- Airflow's executor interface is stable and designed for this kind of replacement
- Jobbers already has submission, status tracking, cancellation, and retry infrastructure
- CeleryExecutor is ~600 lines; a JobbersExecutor would be comparable in scope
- Jobbers adds value over Celery: heartbeat-based stall detection, structured retry policies, explicit cancellation, and DLQ

## Scope

Two deliverables:
1. **Jobbers changes**: built-in Airflow runner task + optional bulk status endpoint
2. **New `airflow-jobbers` package**: `JobbersExecutor` class + state mapping + config

No changes to Airflow core are needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)