### PR TITLE
centralize serialization logic in pydantic models

### DIFF
--- a/jobbers/adapters/redis.py
+++ b/jobbers/adapters/redis.py
@@ -278,13 +278,7 @@ class MsgpackTaskAdapter(SharedTaskAdapterMixin):
 
     def pack(self, task: Task) -> bytes:
         """Serialize a task to msgpack bytes."""
-        d = task.to_dict()
-        d["parent_ids"] = list(task.parent_ids)
-        if task.cron_id is not None:
-            d["cron_id"] = task.cron_id
-        if task.dag_run_id is not None:
-            d["dag_run_id"] = task.dag_run_id
-        return serialize(d)
+        return serialize(task.to_dict())
 
     def unpack(self, task_id: ULID, data: bytes) -> Task:
         """Deserialize a task from msgpack bytes."""

--- a/jobbers/adapters/redis.py
+++ b/jobbers/adapters/redis.py
@@ -2,8 +2,8 @@
 Plain Redis backed implementations (no Redis Stack modules required).
 
 Routing:
-- `RedisRoutingBackend` — stores queue/role/routing config as JSON strings
-  in plain Redis keys and sets. No SQL required.
+- `RedisRoutingBackend` — stores queue/role/routing config as msgpack-encoded
+  binary strings in plain Redis keys and sets. No SQL required.
 
 Task storage / dead-letter queue:
 - `MsgpackTaskAdapter` — stores tasks as msgpack-encoded binary strings,
@@ -15,7 +15,6 @@ Task storage / dead-letter queue:
 from __future__ import annotations
 
 import datetime as dt
-import json
 from typing import TYPE_CHECKING, Any, cast
 
 from ulid import ULID
@@ -29,9 +28,18 @@ from jobbers.utils.serialization import deserialize, serialize
 if TYPE_CHECKING:
     from collections.abc import Awaitable
 
+    from pydantic import BaseModel
     from redis.asyncio.client import Pipeline, Redis
 
     from jobbers.adapters.protocols import TaskAdapterProtocol
+
+
+def _pack(obj: BaseModel, exclude: set[str] | None = None) -> bytes:
+    """Serialize any Pydantic model to msgpack bytes."""
+    kw: dict[str, Any] = {"context": {"mode": "msgpack"}}
+    if exclude:
+        kw["exclude"] = exclude
+    return serialize(obj.model_dump(**kw))
 
 
 # ---------------------------------------------------------------------------
@@ -68,10 +76,10 @@ class RedisRoutingBackend:
         raw = await self._client.get(self.QUEUE_KEY(name=queue))
         if raw is None:
             return None
-        return QueueConfig.model_validate(json.loads(raw))
+        return QueueConfig.model_validate(deserialize(raw))
 
     async def save_queue_config(self, queue_config: QueueConfig) -> None:
-        payload = json.dumps(queue_config.to_dict())
+        payload = _pack(queue_config)
         pipe = self._client.pipeline(transaction=True)
         pipe.set(self.QUEUE_KEY(name=queue_config.name), payload)
         pipe.sadd(self.QUEUES_INDEX, queue_config.name)
@@ -171,10 +179,10 @@ class RedisRoutingBackend:
         raw = await self._client.get(self.ROUTING_KEY(task_name=task_name, task_version=task_version))
         if raw is None:
             return None
-        return RoutingConfig.model_validate(json.loads(raw))
+        return RoutingConfig.model_validate(deserialize(raw))
 
     async def save_routing_config(self, routing_config: RoutingConfig) -> None:
-        payload = json.dumps(routing_config.to_dict())
+        payload = _pack(routing_config)
         await self._client.set(
             self.ROUTING_KEY(task_name=routing_config.task_name, task_version=routing_config.task_version),
             payload,
@@ -278,11 +286,11 @@ class MsgpackTaskAdapter(SharedTaskAdapterMixin):
 
     def pack(self, task: Task) -> bytes:
         """Serialize a task to msgpack bytes."""
-        return serialize(task.to_dict())
+        return _pack(task, exclude={"id"})
 
     def unpack(self, task_id: ULID, data: bytes) -> Task:
         """Deserialize a task from msgpack bytes."""
-        return Task.from_dict(task_id, deserialize(data))
+        return Task.model_validate({"id": task_id, **deserialize(data)})
 
     async def _load_raw(self, key: str) -> bytes | None:
         return cast("bytes | None", await self.data_store.get(key))

--- a/jobbers/adapters/redis_json.py
+++ b/jobbers/adapters/redis_json.py
@@ -299,8 +299,8 @@ class JsonTaskAdapter(SharedTaskAdapterMixin):
     # -- Storage primitives --------------------------------------------------
 
     def pack(self, task: Task) -> str:
-        """Serialize a task to a JSON string."""
-        return json.dumps(task.to_dict())
+        """Serialize a task to a JSON string (float timestamps for RediSearch, string ULIDs)."""
+        return json.dumps(task.model_dump(context={"mode": "redis_json"}, exclude={"id"}))
 
     def unpack(self, task_id: ULID, data: str | dict[str, Any]) -> Task:
         """Deserialize a task from a JSON string or dict."""

--- a/jobbers/adapters/redis_json.py
+++ b/jobbers/adapters/redis_json.py
@@ -314,7 +314,7 @@ class JsonTaskAdapter(SharedTaskAdapterMixin):
         return cast("dict[str, Any] | None", await pipe.json().get(key))  # type: ignore[misc]
 
     def _stage_store(self, pipe: Pipeline, key: str, task: Task) -> None:
-        pipe.json().set(key, "$", task.to_dict())
+        pipe.json().set(key, "$", task.model_dump(context={"mode": "redis_json"}, exclude={"id"}))
 
     def _stage_load(self, pipe: Pipeline, key: str) -> None:
         pipe.json().get(key)

--- a/jobbers/adapters/redis_json.py
+++ b/jobbers/adapters/redis_json.py
@@ -33,6 +33,7 @@ from jobbers.models.task import PaginationOrder, Task, TaskPagination
 from jobbers.models.task_routing import RoutingConfig
 
 if TYPE_CHECKING:
+    from pydantic import BaseModel
     from redis.asyncio.client import Pipeline, Redis
 
     from jobbers.adapters.protocols import TaskAdapterProtocol
@@ -43,6 +44,9 @@ def _escape_tag(value: str) -> str:
     special = set(r',.<>{}[]"\':;!@#$%^&*()\-+=~| ')
     return "".join(f"\\{c}" if c in special else c for c in value)
 
+def _pack(model: BaseModel) -> dict[str, Any]:
+    """Pack a Pydantic model to a dict with RedisJSON-compatible values (e.g. ULIDs as strings)."""
+    return model.model_dump(mode="json", context={"mode": "redis_json"})
 
 # ---------------------------------------------------------------------------
 # RedisJSONRoutingBackend  (Redis Stack: RedisJSON + RediSearch)
@@ -106,7 +110,7 @@ class RedisJSONRoutingBackend:
         return QueueConfig.model_validate(raw)
 
     async def save_queue_config(self, queue_config: QueueConfig) -> None:
-        await self._client.json().set(self.QUEUE_KEY(name=queue_config.name), "$", queue_config.to_dict())  # type: ignore[misc]
+        await self._client.json().set(self.QUEUE_KEY(name=queue_config.name), "$", _pack(queue_config))  # type: ignore[misc]
 
     async def delete_queue(self, queue_name: str) -> None:
         await self._client.delete(self.QUEUE_KEY(name=queue_name))
@@ -203,7 +207,7 @@ class RedisJSONRoutingBackend:
         await self._client.json().set(  # type: ignore[misc]
             self.ROUTING_KEY(task_name=routing_config.task_name, task_version=routing_config.task_version),
             "$",
-            routing_config.to_dict(),
+            _pack(routing_config),
         )
 
     async def delete_routing_config(self, task_name: str, task_version: int) -> bool:
@@ -300,12 +304,12 @@ class JsonTaskAdapter(SharedTaskAdapterMixin):
 
     def pack(self, task: Task) -> str:
         """Serialize a task to a JSON string (float timestamps for RediSearch, string ULIDs)."""
-        return json.dumps(task.model_dump(context={"mode": "redis_json"}, exclude={"id"}))
+        return json.dumps(_pack(task))
 
     def unpack(self, task_id: ULID, data: str | dict[str, Any]) -> Task:
         """Deserialize a task from a JSON string or dict."""
         raw: dict[str, Any] = json.loads(data) if isinstance(data, str) else data
-        return Task.from_dict(task_id, raw)
+        return Task.model_validate({"id": task_id, **raw})
 
     async def _load_raw(self, key: str) -> dict[str, Any] | None:
         return cast("dict[str, Any] | None", await self.data_store.json().get(key))  # type: ignore[misc]
@@ -314,7 +318,7 @@ class JsonTaskAdapter(SharedTaskAdapterMixin):
         return cast("dict[str, Any] | None", await pipe.json().get(key))  # type: ignore[misc]
 
     def _stage_store(self, pipe: Pipeline, key: str, task: Task) -> None:
-        pipe.json().set(key, "$", task.model_dump(context={"mode": "redis_json"}, exclude={"id"}))
+        pipe.json().set(key, "$", json.loads(self.pack(task)))
 
     def _stage_load(self, pipe: Pipeline, key: str) -> None:
         pipe.json().get(key)

--- a/jobbers/models/queue_config.py
+++ b/jobbers/models/queue_config.py
@@ -50,9 +50,6 @@ class QueueConfig(BaseModel):
             case RatePeriod.DAY:
                 return 86400 * self.rate_denominator
 
-    def to_dict(self) -> dict[str, Any]:
-        return self.model_dump()
-
     @classmethod
     def from_row(cls, row: Any) -> Self:
         """Construct from a row (name, max_concurrent, rate_numerator, rate_denominator, rate_period)."""

--- a/jobbers/models/task.py
+++ b/jobbers/models/task.py
@@ -5,6 +5,8 @@ from typing import TYPE_CHECKING, Annotated, Any, Self, get_args, get_origin, ge
 
 from opentelemetry import metrics
 from pydantic import BaseModel, Field, PrivateAttr, TypeAdapter, field_serializer
+from pydantic.functional_serializers import SerializationInfo
+from pydantic.functional_validators import BeforeValidator
 from ulid import ULID
 
 from jobbers.di import get_injected_param_names
@@ -24,6 +26,31 @@ logger = logging.getLogger(__name__)
 meter = metrics.get_meter(__name__)
 
 
+def _parse_timestamp(v: object) -> dt.datetime | None:
+    if v is None or isinstance(v, dt.datetime):
+        return v  # type: ignore[return-value]
+    if isinstance(v, (int, float)):
+        return dt.datetime.fromtimestamp(v, dt.UTC)
+    if isinstance(v, str):
+        return dt.datetime.fromisoformat(v)
+    raise ValueError(f"Cannot parse timestamp: {v!r}")
+
+
+def _parse_ulid(v: object) -> ULID | None:
+    if v is None or isinstance(v, ULID):
+        return v  # type: ignore[return-value]
+    if isinstance(v, str):
+        return ULID.from_str(v)
+    if isinstance(v, (bytes, bytearray)):
+        return ULID.from_bytes(bytes(v))
+    raise ValueError(f"Cannot parse ULID: {v!r}")
+
+
+Timestamp = Annotated[dt.datetime | None, BeforeValidator(_parse_timestamp)]
+ULIDField = Annotated[ULID, BeforeValidator(_parse_ulid)]
+OptionalULIDField = Annotated[ULID | None, BeforeValidator(_parse_ulid)]
+
+
 class Task(BaseModel):
     """A task to be executed."""
 
@@ -38,31 +65,65 @@ class Task(BaseModel):
     # status fields
     retry_attempt: int = 0  # Number of times this task has been retried
     status: TaskStatus = Field(default=TaskStatus.UNSUBMITTED)
-    submitted_at: dt.datetime | None = None
-    retried_at: dt.datetime | None = None
-    started_at: dt.datetime | None = None
-    heartbeat_at: dt.datetime | None = None
-    completed_at: dt.datetime | None = None
+    submitted_at: Timestamp = None
+    retried_at: Timestamp = None
+    started_at: Timestamp = None
+    heartbeat_at: Timestamp = None
+    completed_at: Timestamp = None
 
     task_config: TaskConfig | None = Field(default=None, exclude=True)
     dag_callbacks: list[DAGCallback] = Field(default_factory=list)
     # Immediate parent task IDs — empty for root tasks, one entry for simple-chain
     # and dynamic fan-out children, many entries for fan-in collectors.
-    parent_ids: list[ULID] = Field(default_factory=list)
+    parent_ids: list[ULIDField] = Field(default_factory=list)
     # When True, the worker fetches parent results via parent_ids and injects them
     # as a `parent_results` kwarg before calling the task function.
     inject_parent_results: bool = False
     # Set on cron-dispatched root tasks so the worker can clear the active-run key on completion.
-    cron_id: ULID | None = Field(default=None)
+    cron_id: OptionalULIDField = Field(default=None)
     # Shared across every task in a DAG run; None for standalone tasks.
     # Generated once at submission time (submit_dag / dispatch_cron_dag) and propagated to all
     # descendants via generate_callbacks, generate_error_callbacks, and _handle_dynamic_fanout.
-    dag_run_id: ULID | None = Field(default=None)
+    dag_run_id: OptionalULIDField = Field(default=None)
 
     @field_serializer("id", when_used="json")
     def serialize_id(self, value: ULID) -> str:
-        """Serialize ULID to string for JSON output."""
         return str(value)
+
+    @field_serializer("submitted_at", "retried_at", "started_at", "heartbeat_at", "completed_at")
+    def serialize_timestamp(
+        self, value: dt.datetime | None, info: SerializationInfo
+    ) -> float | str | dt.datetime | None:
+        if value is None:
+            return None
+        mode = (info.context or {}).get("mode")
+        if mode == "msgpack":
+            return value  # msgpack ExtType(1) handles datetime → binary
+        if mode == "redis_json":
+            return value.timestamp()  # float for RediSearch NumericField
+        return value.isoformat()  # ISO string for SQL columns and API responses
+
+    @field_serializer("cron_id", "dag_run_id")
+    def serialize_optional_ulid(
+        self, value: ULID | None, info: SerializationInfo
+    ) -> ULID | str | None:
+        if value is None:
+            return None
+        if (info.context or {}).get("mode") == "msgpack":
+            return value  # msgpack ExtType(3) handles ULID → binary
+        return str(value)
+
+    @field_serializer("parent_ids")
+    def serialize_parent_ids(
+        self, value: list[ULID], info: SerializationInfo
+    ) -> list[ULID] | list[str]:
+        if (info.context or {}).get("mode") == "msgpack":
+            return list(value)  # msgpack ExtType(3) handles each ULID → binary
+        return [str(v) for v in value]
+
+    @field_serializer("dag_callbacks")
+    def serialize_dag_callbacks(self, value: list[DAGCallback]) -> list[dict[str, Any]]:
+        return [cb.model_dump(mode="json") for cb in value]
 
     def valid_task_params(self) -> bool:
         if not self.task_config:
@@ -236,63 +297,13 @@ class Task(BaseModel):
         return results_list[0] if len(results_list) == 1 else results_list
 
     def to_dict(self) -> dict[str, Any]:
-        """Serialize task fields to a dict for RedisJSON storage."""
-
-        def _ts(d: dt.datetime | None) -> float | None:
-            return d.timestamp() if d is not None else None
-
-        return {
-            "name": self.name,
-            "queue": self.queue,
-            "version": self.version,
-            "parameters": self.parameters or {},
-            "results": self.results or {},
-            "errors": self.errors,
-            "retry_attempt": self.retry_attempt,
-            "status": str(self.status),
-            "submitted_at": _ts(self.submitted_at),
-            "retried_at": _ts(self.retried_at),
-            "started_at": _ts(self.started_at),
-            "heartbeat_at": _ts(self.heartbeat_at),
-            "completed_at": _ts(self.completed_at),
-            "dag_callbacks": [cb.model_dump(mode="json") for cb in self.dag_callbacks],
-            "parent_ids": [str(pid) for pid in self.parent_ids],
-            "inject_parent_results": self.inject_parent_results,
-            "cron_id": str(self.cron_id) if self.cron_id is not None else None,
-            "dag_run_id": str(self.dag_run_id) if self.dag_run_id is not None else None,
-        }
+        """Serialize for msgpack storage — datetimes and ULIDs passed as objects for ExtType encoding."""
+        return self.model_dump(context={"mode": "msgpack"}, exclude={"id"})
 
     @classmethod
     def from_dict(cls, task_id: ULID, raw: dict[str, Any]) -> "Self":
-        """Construct a Task from a plain dict (as produced by to_dict())."""
-
-        def _dt(ts: float | None) -> dt.datetime | None:
-            return dt.datetime.fromtimestamp(ts, dt.UTC) if ts is not None else None
-
-        def _ulid(v: ULID | str) -> ULID:
-            return v if isinstance(v, ULID) else ULID.from_str(v)
-
-        return cls(
-            id=task_id,
-            name=raw.get("name", ""),
-            queue=raw.get("queue", "default"),
-            version=raw.get("version", 0),
-            parameters=raw.get("parameters") or {},
-            results=raw.get("results") or {},
-            errors=raw.get("errors") or [],
-            retry_attempt=raw.get("retry_attempt", 0),
-            status=raw.get("status", TaskStatus.UNSUBMITTED),
-            submitted_at=_dt(raw.get("submitted_at")),
-            retried_at=_dt(raw.get("retried_at")),
-            started_at=_dt(raw.get("started_at")),
-            heartbeat_at=_dt(raw.get("heartbeat_at")),
-            completed_at=_dt(raw.get("completed_at")),
-            dag_callbacks=_dag_callback_adapter.validate_python(raw.get("dag_callbacks") or []),
-            parent_ids=[_ulid(p) for p in raw.get("parent_ids") or []],
-            inject_parent_results=raw.get("inject_parent_results", False),
-            cron_id=_ulid(raw["cron_id"]) if raw.get("cron_id") else None,
-            dag_run_id=_ulid(raw["dag_run_id"]) if raw.get("dag_run_id") else None,
-        )
+        """Construct a Task from any storage dict (msgpack, redis_json, or SQL)."""
+        return cls.model_validate({"id": task_id, **raw})
 
     def set_status(self, status: TaskStatus) -> None:
         match status:

--- a/jobbers/models/task.py
+++ b/jobbers/models/task.py
@@ -266,9 +266,9 @@ class Task(BaseModel):
 
     def summarized(self) -> dict[str, Any]:
         summary = self.model_dump(
+            mode="json",
             include={"id", "name", "parameters", "status", "retry_attempt", "submitted_at"}
         )
-        summary["id"] = str(self.id)
         if self.errors:
             summary["last_error"] = self.errors[-1]
         return summary
@@ -295,15 +295,6 @@ class Task(BaseModel):
         tasks = await self._adapter.get_tasks_bulk(self.parent_ids)
         results_list = [t.results if t is not None else {} for t in tasks]
         return results_list[0] if len(results_list) == 1 else results_list
-
-    def to_dict(self) -> dict[str, Any]:
-        """Serialize for msgpack storage — datetimes and ULIDs passed as objects for ExtType encoding."""
-        return self.model_dump(context={"mode": "msgpack"}, exclude={"id"})
-
-    @classmethod
-    def from_dict(cls, task_id: ULID, raw: dict[str, Any]) -> "Self":
-        """Construct a Task from any storage dict (msgpack, redis_json, or SQL)."""
-        return cls.model_validate({"id": task_id, **raw})
 
     def set_status(self, status: TaskStatus) -> None:
         match status:

--- a/jobbers/models/task_routing.py
+++ b/jobbers/models/task_routing.py
@@ -43,9 +43,6 @@ class RoutingConfig(BaseModel):
                 raise ValueError("WEIGHTED routing requires weights with the same length as queues")
         return self
 
-    def to_dict(self) -> dict[str, Any]:
-        return self.model_dump()
-
     @classmethod
     def from_row(cls, row: Any) -> Self:
         """Construct from a DB row (task_name, task_version, strategy, queues_json, weights_json)."""

--- a/jobbers/task_routes.py
+++ b/jobbers/task_routes.py
@@ -225,7 +225,7 @@ async def create_queue(queue_config: QueueConfig) -> dict[str, Any]:
     if existing is not None:
         raise HTTPException(status_code=409, detail=f"Queue '{queue_config.name}' already exists.")
     await sm.save_queue_config(queue_config)
-    return {"message": "Queue created successfully", "queue": queue_config.model_dump()}
+    return {"message": "Queue created successfully", "queue": queue_config.model_dump(mode="json")}
 
 
 @app.get("/queues/{queue_name}/config")
@@ -234,7 +234,7 @@ async def get_queue_config(queue_name: str) -> dict[str, Any]:
     config = await db.get_state_manager().get_queue_config(queue_name)
     if config is None:
         raise HTTPException(status_code=404, detail=f"Queue '{queue_name}' not found.")
-    return {"queue": config.model_dump()}
+    return {"queue": config.model_dump(mode="json")}
 
 
 @app.put("/queues/{queue_name}")
@@ -242,8 +242,7 @@ async def update_queue(queue_name: str, queue_config: QueueConfig) -> dict[str, 
     """Create or update the configuration for a queue. The name in the body is ignored; the path name is used."""
     queue_config.name = queue_name
     await db.get_state_manager().save_queue_config(queue_config)
-    return {"message": "Queue updated successfully", "queue": queue_config.model_dump()}
-
+    return {"message": "Queue updated successfully", "queue": queue_config.model_dump(mode="json")}
 
 @app.delete("/queues/{queue_name}", status_code=200)
 async def delete_queue(queue_name: str) -> dict[str, Any]:
@@ -470,7 +469,7 @@ async def get_task_routing(task_name: str, task_version: int) -> dict[str, Any]:
     config = await db.get_state_manager().get_routing_config(task_name, task_version)
     if config is None:
         raise HTTPException(status_code=404, detail=f"No routing config for '{task_name}' v{task_version}.")
-    return {"routing": config.model_dump()}
+    return {"routing": config.model_dump(mode="json")}
 
 
 @app.put("/task-routing/{task_name}/{task_version}")
@@ -481,7 +480,7 @@ async def update_task_routing(
     routing_config.task_name = task_name
     routing_config.task_version = task_version
     await db.get_state_manager().save_routing_config(routing_config)
-    return {"message": "Task routing updated successfully", "routing": routing_config.model_dump()}
+    return {"message": "Task routing updated successfully", "routing": routing_config.model_dump(mode="json")}
 
 
 @app.delete("/task-routing/{task_name}/{task_version}", status_code=200)

--- a/tests/models/test_task.py
+++ b/tests/models/test_task.py
@@ -236,8 +236,8 @@ def _make_full_task(**overrides) -> Task:
 def test_to_dict_round_trip():
     """from_dict(to_dict()) reproduces the original task."""
     task = _make_full_task()
-    d = task.to_dict()
-    restored = Task.from_dict(task.id, d)
+    d = task.model_dump(context={"mode": "msgpack"}, exclude={"id"})
+    restored = Task.model_validate({"id": task.id, **d})
     assert restored.id == task.id
     assert restored.name == task.name
     assert restored.parameters == task.parameters
@@ -248,8 +248,8 @@ def test_to_dict_round_trip():
 
 def test_from_dict_missing_parent_ids_defaults_to_empty():
     """from_dict handles a dict with no parent_ids gracefully."""
-    minimal = {"name": "t", "queue": "default", "version": 1, "status": "submitted"}
-    task = Task.from_dict(ULID1, minimal)
+    minimal = {"id": ULID1, "name": "t", "queue": "default", "version": 1, "status": "submitted"}
+    task = Task.model_validate(minimal)
     assert task.parent_ids == []
 
 
@@ -264,8 +264,8 @@ def test_to_dict_preserves_dag_callbacks():
         status=TaskStatus.SUBMITTED,
         dag_callbacks=[SimpleCallback(task=child_spec)],
     )
-    d = task.to_dict()
-    restored = Task.from_dict(ULID1, d)
+    d = task.model_dump(context={"mode": "msgpack"}, exclude={"id"})
+    restored = Task.model_validate({"id": ULID1, **d})
     assert len(restored.dag_callbacks) == 1
     assert isinstance(restored.dag_callbacks[0], SimpleCallback)
     assert restored.dag_callbacks[0].task.name == "child"
@@ -690,13 +690,13 @@ def test_valid_task_params_still_checks_provided_params():
 def test_to_dict_round_trip_preserves_inject_flag():
     """inject_parent_results survives a to_dict/from_dict round-trip."""
     task = _make_full_task(inject_parent_results=True)
-    d = task.to_dict()
-    restored = Task.from_dict(task.id, d)
+    d = task.model_dump(context={"mode": "msgpack"}, exclude={"id"})
+    restored = Task.model_validate({"id": task.id, **d})
     assert restored.inject_parent_results is True
 
 
 def test_from_dict_missing_inject_flag_defaults_false():
     """from_dict defaults inject_parent_results to False for records that predate the field."""
-    minimal = {"name": "t", "queue": "default", "version": 1, "status": "submitted"}
-    task = Task.from_dict(ULID1, minimal)
+    minimal = {"id": ULID1, "name": "t", "queue": "default", "version": 1, "status": "submitted"}
+    task = Task.model_validate(minimal)
     assert task.inject_parent_results is False


### PR DESCRIPTION
resolves #65 

pack and unpack handle converting from a python object into bytes, str, or whatever format the database adapter will require. this ensures we use the correct parameters when calling model_dump.

serialization should be handled only at the edges and so the models should not have need to implement serialization helpers