### PR TITLE
Add name and aggregate status to DAG runs

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -122,6 +122,12 @@ button, .btn {
 .status-scheduled  { background: #e0f2fe; color: #0369a1; }
 .status-unsubmitted { background: #f9fafb; color: #6b7280; }
 
+/* ── DAG run status badges (aggregate run status, distinct from per-task status) ── */
+.dag-status-running         { background: #dbeafe; color: #1d4ed8; }
+.dag-status-complete        { background: #dcfce7; color: #166534; }
+.dag-status-partial_failure { background: #ffedd5; color: #9a3412; }
+.dag-status-failed          { background: #fee2e2; color: #991b1b; }
+
 /* ── Misc ── */
 .error-msg { color: #dc3545; margin-top: .5rem; }
 .loading-msg { color: #666; }

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -189,9 +189,10 @@ export const deleteRole = (name) => del(`/roles/${name}`)
 /**
  * POST /submit-dag
  * @param {string} diagram  Mermaid flowchart TD text
- * @returns {{ root_task_ids: string[] }}
+ * @param {string} [name]  Human-readable name for this DAG run. Defaults to the generated dag_run_id if omitted.
+ * @returns {{ dag_run_id: string, root_task_ids: string[] }}
  */
-export const submitDag = (diagram) => post('/submit-dag', { diagram })
+export const submitDag = (diagram, name) => post('/submit-dag', { diagram, name: name || null })
 
 // ── Cron DAGs ──────────────────────────────────────────────────────────────────
 
@@ -245,13 +246,13 @@ export const deleteCronDag = (cronId) => del(`/cron-dags/${cronId}`)
 /**
  * GET /dags
  * @param {{ limit?: number, offset?: number }} [params]
- * @returns {{ total: number, dags: { dag_run_id: string, submitted_at: string }[] }}
+ * @returns {{ total: number, dags: { dag_run_id: string, name: string, status: string, submitted_at: string }[] }}
  */
 export const listDags = (params) => get('/dags', params)
 
 /**
  * GET /dags/{dag_run_id}
  * @param {string} dagRunId
- * @returns {{ dag_run_id: string, submitted_at: string, task_ids: string[] }}
+ * @returns {{ dag_run_id: string, name: string, status: string, submitted_at: string, task_ids: string[] }}
  */
 export const getDag = (dagRunId) => get(`/dags/${dagRunId}`)

--- a/frontend/src/components/DagStatusBadge.jsx
+++ b/frontend/src/components/DagStatusBadge.jsx
@@ -1,0 +1,10 @@
+/**
+ * Renders a coloured pill for a DAG run's aggregate status string.
+ * Matches the DagRunStatus StrEnum values from the backend
+ * (running / complete / partial_failure / failed) -- distinct from per-task
+ * TaskStatus values, so this uses its own dag-status-* colour classes.
+ */
+export default function DagStatusBadge({ status }) {
+  const cls = `status-badge dag-status-${status?.toLowerCase() ?? 'running'}`
+  return <span className={cls}>{status ?? 'unknown'}</span>
+}

--- a/frontend/src/pages/DagDetail.jsx
+++ b/frontend/src/pages/DagDetail.jsx
@@ -2,6 +2,7 @@ import mermaid from 'mermaid'
 import { useEffect, useState } from 'react'
 import { Link, useParams } from 'react-router-dom'
 import { getDag, getTaskStatus } from '../api/client'
+import DagStatusBadge from '../components/DagStatusBadge'
 import StatusBadge from '../components/StatusBadge'
 
 mermaid.initialize({ startOnLoad: false, theme: 'default' })
@@ -110,6 +111,8 @@ export default function DagDetail() {
         <table style={{ width: 'auto' }}>
           <tbody>
             <tr><th>DAG Run ID</th><td className="monospace" style={{ fontSize: '0.85rem' }}>{run.dag_run_id}</td></tr>
+            <tr><th>Name</th><td>{run.name ?? '—'}</td></tr>
+            <tr><th>Status</th><td><DagStatusBadge status={run.status} /></td></tr>
             <tr><th>Submitted at</th><td>{formatTs(run.submitted_at)}</td></tr>
             <tr><th>Tasks</th><td>{run.task_ids?.length ?? 0}</td></tr>
           </tbody>

--- a/frontend/src/pages/DagList.jsx
+++ b/frontend/src/pages/DagList.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { listDags } from '../api/client'
+import DagStatusBadge from '../components/DagStatusBadge'
 
 const PAGE_SIZE = 25
 
@@ -48,6 +49,8 @@ export default function DagList() {
             <thead>
               <tr>
                 <th>DAG Run ID</th>
+                <th>Name</th>
+                <th>Status</th>
                 <th>Submitted at</th>
               </tr>
             </thead>
@@ -59,6 +62,8 @@ export default function DagList() {
                       {dag.dag_run_id}
                     </Link>
                   </td>
+                  <td>{dag.name ?? '—'}</td>
+                  <td><DagStatusBadge status={dag.status} /></td>
                   <td>{dag.submitted_at ? new Date(dag.submitted_at).toLocaleString() : '—'}</td>
                 </tr>
               ))}

--- a/frontend/src/pages/SubmitDAG.jsx
+++ b/frontend/src/pages/SubmitDAG.jsx
@@ -19,6 +19,7 @@ const PLACEHOLDER = `flowchart TD
     B -.-> err`
 
 export default function SubmitDAG() {
+  const [name, setName]           = useState('')
   const [diagram, setDiagram]     = useState(PLACEHOLDER)
   const [svgHtml, setSvgHtml]     = useState('')
   const [parseError, setParseError] = useState(null)
@@ -50,7 +51,7 @@ export default function SubmitDAG() {
     setSubmitError(null)
     setResult(null)
     try {
-      const res = await submitDag(diagram)
+      const res = await submitDag(diagram, name)
       setResult(res)
     } catch (e) {
       setSubmitError(e.message)
@@ -71,6 +72,14 @@ export default function SubmitDAG() {
         <div className="card" style={{ margin: 0 }}>
           <h2 style={{ marginTop: 0 }}>Diagram</h2>
           <form onSubmit={handleSubmit}>
+            <div className="form-row">
+              <label>Name</label>
+              <input
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="Defaults to the generated run ID if left blank"
+              />
+            </div>
             <textarea
               value={diagram}
               onChange={(e) => setDiagram(e.target.value)}

--- a/jobbers/adapters/_shared.py
+++ b/jobbers/adapters/_shared.py
@@ -1,9 +1,16 @@
 """
 Shared base classes for Redis-backed task adapters.
 
-``SharedTaskAdapterMixin`` is an internal ABC that implements all ``TaskStateProtocol``
+``SharedTaskAdapterMixin`` is an internal ABC that implements the ``TaskStateProtocol``
 and ``AtomicTaskStateProtocol`` logic identical across the plain-Redis and RedisJSON
-backends.  It is not part of the public adapter API.
+backends. It is not part of the public adapter API.
+
+DAG-run-index methods (``stage_register_dag_run``, ``get_dag_runs``, ``get_dag_run``,
+``clean_dag_runs``) are *not* here — they live per-backend in ``redis/task_state.py``
+and ``redis_json/task_state.py``, since the two backends store DAG-run name/status
+metadata in genuinely different native shapes. Fan-in tracking and the pending/closed
+completion counter (``close_dag_run_task`` and friends) are unaffected by that and
+remain shared here.
 
 ``_SharedRedisTaskSubmitBase`` is an internal base that implements ``TaskSubmitProtocol``
 (submit_task, submit_rate_limited_task, get_next_task) shared across both Redis backends.
@@ -41,7 +48,7 @@ if TYPE_CHECKING:
 
     from redis.asyncio.client import Pipeline, Redis
 
-    from jobbers.models.dag import DAGRunPagination
+    from jobbers.models.dag import DAGRunDetail, DagRunOutcome, DAGRunPagination, DAGRunSummary
     from jobbers.models.queue_config import QueueConfig
     from jobbers.models.task import Task, TaskPagination
     from jobbers.protocols import TransactionHandle
@@ -60,7 +67,6 @@ class SharedTaskAdapterMixin(ABC):
     TASK_BY_TYPE_IDX = "task-type-idx:{name}".format
     QUEUE_RATE_LIMITER = "rate-limiter:{queue}".format
     DLQ_MISSING_DATA = "dlq-missing-data"
-    DAG_RUNS = "dag-runs"
     # Per-DAG-run structures — flat key count regardless of task count or fan-out nesting depth.
     DAG_RUN_PENDING = "dag-run:{dag_run_id}:pending".format  # Set: task IDs submitted, not yet closed.
     DAG_RUN_CLOSED = "dag-run:{dag_run_id}:closed".format  # Set: task IDs that have closed.
@@ -173,6 +179,33 @@ class SharedTaskAdapterMixin(ABC):
     @abstractmethod
     async def get_all_tasks(self, pagination: TaskPagination) -> list[Task]:
         """Return a page of tasks matching the pagination filters."""
+
+    # DAG-run-index primitives — backend-specific because RedisTaskState and
+    # RedisJSONTaskState store run name/status/counters in different native shapes
+    # (a flat-field Hash vs. a JSON document per run).
+    @abstractmethod
+    def stage_register_dag_run(self, pipe: TransactionHandle, task: Task) -> None:
+        """Stage DAG run index + metadata registration onto pipe if task belongs to a DAG run."""
+
+    @abstractmethod
+    async def get_dag_runs(self, pagination: DAGRunPagination) -> tuple[list[DAGRunSummary], int]:
+        """Return a paginated list of DAG runs ordered by submission time (oldest first)."""
+
+    @abstractmethod
+    async def get_dag_run(self, dag_run_id: ULID) -> DAGRunDetail | None:
+        """Return details for a DAG run, or None if not registered."""
+
+    @abstractmethod
+    async def clean_dag_runs(self, now: dt.datetime, max_age: dt.timedelta) -> None:
+        """Remove DAG run index entries and all their per-run structures older than ``max_age``."""
+
+    @abstractmethod
+    async def record_dag_run_task_terminal(self, dag_run_id: ULID, outcome: DagRunOutcome) -> None:
+        """Atomically increment the run's completed/failed counters and recompute+persist status."""
+
+    @abstractmethod
+    async def mark_dag_run_complete(self, dag_run_id: ULID) -> None:
+        """Set status='complete' iff failed_count == 0. No-op if the run's record is missing."""
 
     # ---------------------------------------------------------------------------
     # Shared implementations (identical across all backends)
@@ -323,66 +356,6 @@ class SharedTaskAdapterMixin(ABC):
         p.zadd(self.TASKS_BY_QUEUE(queue=task.queue), {bytes(task.id): task.submitted_at.timestamp()})
         self.stage_save(pipe, task)
         self.stage_register_dag_run(pipe, task)
-
-    def stage_register_dag_run(self, pipe: TransactionHandle, task: Task) -> None:
-        """Stage DAG run index updates onto pipe if the task belongs to a DAG run."""
-        if task.dag_run_id is None or task.submitted_at is None:
-            return
-        score = task.submitted_at.timestamp()
-        p: Any = pipe
-        p.zadd(self.DAG_RUNS, {bytes(task.dag_run_id): score}, nx=True)
-        p.sadd(self.DAG_RUN_PENDING(dag_run_id=task.dag_run_id), bytes(task.id))
-
-    async def get_dag_runs(self, pagination: DAGRunPagination) -> tuple[list[tuple[ULID, dt.datetime]], int]:
-        """Return a paginated list of DAG runs ordered by submission time (oldest first)."""
-        total: int = await self.data_store.zcard(self.DAG_RUNS)
-        raw = cast(
-            "list[tuple[bytes, float]]",
-            await self.data_store.zrange(
-                self.DAG_RUNS, pagination.offset, pagination.offset + pagination.limit - 1, withscores=True
-            ),
-        )
-        return [
-            (ULID.from_bytes(dag_id_bytes), dt.datetime.fromtimestamp(score, dt.UTC))
-            for dag_id_bytes, score in raw
-        ], total
-
-    async def get_dag_run(self, dag_run_id: ULID) -> tuple[dt.datetime, list[ULID]] | None:
-        """Return (submitted_at, task_ids) for a DAG run via SUNION(pending, closed)."""
-        score: float | None = await self.data_store.zscore(self.DAG_RUNS, bytes(dag_run_id))
-        if score is None:
-            return None
-        submitted_at = dt.datetime.fromtimestamp(score, dt.UTC)
-        raw_ids = cast(
-            "set[bytes]",
-            await self.data_store.sunion(
-                [self.DAG_RUN_PENDING(dag_run_id=dag_run_id), self.DAG_RUN_CLOSED(dag_run_id=dag_run_id)]
-            ),
-        )
-        # SUNION has no ordering guarantee; ULIDs sort lexicographically by creation
-        # time, so sorting restores the submission-order guarantee callers rely on
-        # (e.g. the /dags/{dag_run_id} response) at no extra I/O cost.
-        task_ids = sorted(ULID.from_bytes(b) for b in raw_ids)
-        return submitted_at, task_ids
-
-    async def clean_dag_runs(self, now: dt.datetime, max_age: dt.timedelta) -> None:
-        """Remove DAG run index entries and all their per-run structures older than ``max_age``."""
-        cutoff = (now - max_age).timestamp()
-        stale = cast("list[bytes]", await self.data_store.zrange(self.DAG_RUNS, "-inf", cutoff, byscore=True))
-        if not stale:
-            return
-        pipe = self.data_store.pipeline(transaction=False)
-        pipe.zrem(self.DAG_RUNS, *stale)
-        for dag_id_bytes in stale:
-            try:
-                dag_run_id = ULID.from_bytes(dag_id_bytes)
-            except ValueError:
-                continue
-            pipe.delete(self.DAG_RUN_PENDING(dag_run_id=dag_run_id))
-            pipe.delete(self.DAG_RUN_CLOSED(dag_run_id=dag_run_id))
-            pipe.delete(self.DAG_RUN_FANIN(dag_run_id=dag_run_id))
-            pipe.delete(self.DAG_RUN_FANIN_MEMBERS(dag_run_id=dag_run_id))
-        await pipe.execute()
 
     async def save_task(self, task: Task) -> None:
         """Save task state to the Redis data store."""
@@ -601,6 +574,8 @@ class _SharedRedisTaskSubmitBase:
     QUEUE_RATE_LIMITER = "rate-limiter:{queue}".format
     DAG_RUNS = "dag-runs"
     DAG_RUN_PENDING = "dag-run:{dag_run_id}:pending".format
+    # Identical key pattern on both Redis backends (flat Hash vs. JSON doc, same name).
+    DAG_RUN_META = "dag-run:{dag_run_id}:meta".format
     DLQ_MISSING_DATA = "dlq-missing-data"
 
     def __init__(
@@ -638,7 +613,11 @@ class _SharedRedisTaskSubmitBase:
         if task.dag_run_id is not None:
             pipe.zadd(self.DAG_RUNS, {bytes(task.dag_run_id): task.submitted_at.timestamp()}, nx=True)
             pipe.sadd(self.DAG_RUN_PENDING(dag_run_id=task.dag_run_id), bytes(task.id))
+            self._stage_dag_run_meta_seed(pipe, task)
         await pipe.execute()
+
+    def _stage_dag_run_meta_seed(self, pipe: Pipeline, task: Task) -> None:
+        """Backend-specific DAG-run meta seeding; no-op by default (overridden per backend)."""
 
     async def submit_task(self, task: Task) -> bool:
         """Atomically enqueue a new task with no rate limiting. Status must already be SUBMITTED."""
@@ -661,6 +640,7 @@ class _SharedRedisTaskSubmitBase:
                 is_active,
                 self._pack_fn(task),
                 dag_run_id_bytes,
+                task.dag_run_name or "",
             ),
         )
         return result == 1
@@ -691,6 +671,7 @@ class _SharedRedisTaskSubmitBase:
                 is_active,
                 self._pack_fn(task),
                 dag_run_id_bytes,
+                task.dag_run_name or "",
             ),
         )
         return result == 1

--- a/jobbers/adapters/_shared.py
+++ b/jobbers/adapters/_shared.py
@@ -512,6 +512,24 @@ class SharedTaskAdapterMixin(ABC):
         )
         return int(results[1])
 
+    async def stage_close_dag_run_task(
+        self, pipe: TransactionHandle, dag_run_id: ULID, task_id: ULID
+    ) -> None:
+        """
+        Stage close_dag_run_task's SREM/SADD/SCARD move onto pipe (part of AtomicDagRunProtocol).
+
+        Must be awaited: registered Lua scripts are coroutines under redis-py's async
+        client even when `client` is a pipeline -- awaiting only queues the EVALSHA
+        command here, it does not execute it. The real [removed, remaining] result is
+        only available in the list returned by the eventual `await pipe.execute()`.
+        """
+        p: Any = pipe
+        await self._close_dag_run_task_script(
+            keys=[self.DAG_RUN_PENDING(dag_run_id=dag_run_id), self.DAG_RUN_CLOSED(dag_run_id=dag_run_id)],
+            args=[bytes(task_id)],
+            client=p,
+        )
+
     async def task_exists(self, task_id: ULID) -> bool:
         does_exists: int = await self.data_store.exists(self.TASK_DETAILS(task_id=task_id))
         return does_exists == 1

--- a/jobbers/adapters/redis/task_state.py
+++ b/jobbers/adapters/redis/task_state.py
@@ -6,17 +6,52 @@ Plain Redis task state adapter.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, cast
+import datetime as dt
+from typing import TYPE_CHECKING, Any, cast
 
 from ulid import ULID
 
 from jobbers.adapters._shared import SharedTaskAdapterMixin
 from jobbers.adapters.redis._helpers import _pack
+from jobbers.models.dag import DAGRunDetail, DagRunStatus, DAGRunSummary
 from jobbers.models.task import PaginationOrder, Task, TaskPagination
 from jobbers.utils.serialization import deserialize
 
 if TYPE_CHECKING:
-    from redis.asyncio.client import Pipeline
+    from redis.asyncio.client import Pipeline, Redis
+
+    from jobbers.models.dag import DagRunOutcome, DAGRunPagination
+    from jobbers.protocols import TransactionHandle
+
+
+# Atomically increments the run's completed/failed field in its per-run meta Hash and
+# recomputes+persists the aggregate status. Returns 0 if the run's meta hash is missing
+# (already cleaned up), 1 otherwise. Never itself produces 'complete' -- that's written
+# separately by mark_dag_run_complete, gated on failed_count == 0.
+_RECORD_DAG_RUN_TERMINAL_SCRIPT = """
+    if redis.call('EXISTS', KEYS[1]) == 0 then return 0 end
+    local field = 'failed'
+    if ARGV[1] == 'completed' then field = 'completed' end
+    redis.call('HINCRBY', KEYS[1], field, 1)
+    local completed = tonumber(redis.call('HGET', KEYS[1], 'completed')) or 0
+    local failed = tonumber(redis.call('HGET', KEYS[1], 'failed')) or 0
+    local status = 'running'
+    if failed > 0 then
+        if completed > 0 then status = 'partial_failure' else status = 'failed' end
+    end
+    redis.call('HSET', KEYS[1], 'status', status)
+    return 1
+"""
+
+# Sets status='complete' iff failed_count == 0. No-op (returns 0) if the run's meta hash
+# is missing. Idempotent: safe to call more than once, e.g. under concurrent last-completer
+# races.
+_MARK_DAG_RUN_COMPLETE_SCRIPT = """
+    if redis.call('EXISTS', KEYS[1]) == 0 then return 0 end
+    local failed = tonumber(redis.call('HGET', KEYS[1], 'failed')) or 0
+    if failed == 0 then redis.call('HSET', KEYS[1], 'status', 'complete') end
+    return 1
+"""
 
 
 class RedisTaskState(SharedTaskAdapterMixin):
@@ -27,6 +62,15 @@ class RedisTaskState(SharedTaskAdapterMixin):
     `get_all_tasks` applies `task_name`, `task_version`, and `status` filters in Python
     after fetching candidate task IDs from the queue sorted set.
     """
+
+    DAG_RUNS = "dag-runs"
+    # Hash per run: name, status, completed (int), failed (int).
+    DAG_RUN_META = "dag-run:{dag_run_id}:meta".format
+
+    def __init__(self, data_store: Redis) -> None:
+        super().__init__(data_store)
+        self._record_dag_run_terminal_script = data_store.register_script(_RECORD_DAG_RUN_TERMINAL_SCRIPT)
+        self._mark_dag_run_complete_script = data_store.register_script(_MARK_DAG_RUN_COMPLETE_SCRIPT)
 
     # -- Storage primitives --------------------------------------------------
 
@@ -100,3 +144,101 @@ class RedisTaskState(SharedTaskAdapterMixin):
                 continue
             results.append(task)
         return results
+
+    # -- DAG run index --------------------------------------------------------
+
+    def stage_register_dag_run(self, pipe: TransactionHandle, task: Task) -> None:
+        """Stage DAG run index + metadata registration onto pipe if the task belongs to a DAG run."""
+        if task.dag_run_id is None or task.submitted_at is None:
+            return
+        score = task.submitted_at.timestamp()
+        p: Any = pipe
+        p.zadd(self.DAG_RUNS, {bytes(task.dag_run_id): score}, nx=True)
+        p.sadd(self.DAG_RUN_PENDING(dag_run_id=task.dag_run_id), bytes(task.id))
+        meta_key = self.DAG_RUN_META(dag_run_id=task.dag_run_id)
+        p.hsetnx(meta_key, "name", task.dag_run_name or "")
+        p.hsetnx(meta_key, "status", DagRunStatus.RUNNING.value)
+        p.hsetnx(meta_key, "completed", 0)
+        p.hsetnx(meta_key, "failed", 0)
+
+    async def get_dag_runs(self, pagination: DAGRunPagination) -> tuple[list[DAGRunSummary], int]:
+        """Return a paginated list of DAG runs ordered by submission time (oldest first)."""
+        total: int = await self.data_store.zcard(self.DAG_RUNS)
+        raw = cast(
+            "list[tuple[bytes, float]]",
+            await self.data_store.zrange(
+                self.DAG_RUNS, pagination.offset, pagination.offset + pagination.limit - 1, withscores=True
+            ),
+        )
+        pipe = self.data_store.pipeline(transaction=False)
+        for dag_id_bytes, _ in raw:
+            pipe.hmget(self.DAG_RUN_META(dag_run_id=ULID.from_bytes(dag_id_bytes)), "name", "status")
+        meta_rows = cast("list[list[bytes | None]]", await pipe.execute()) if raw else []
+        summaries = [
+            DAGRunSummary(
+                dag_run_id=ULID.from_bytes(dag_id_bytes),
+                name=name.decode() if name else "",
+                status=DagRunStatus(status.decode()) if status else DagRunStatus.RUNNING,
+                submitted_at=dt.datetime.fromtimestamp(score, dt.UTC),
+            )
+            for (dag_id_bytes, score), (name, status) in zip(raw, meta_rows, strict=True)
+        ]
+        return summaries, total
+
+    async def get_dag_run(self, dag_run_id: ULID) -> DAGRunDetail | None:
+        """Return details for a DAG run via SUNION(pending, closed), or None if not registered."""
+        score: float | None = await self.data_store.zscore(self.DAG_RUNS, bytes(dag_run_id))
+        if score is None:
+            return None
+        submitted_at = dt.datetime.fromtimestamp(score, dt.UTC)
+        raw_ids = cast(
+            "set[bytes]",
+            await self.data_store.sunion(
+                [self.DAG_RUN_PENDING(dag_run_id=dag_run_id), self.DAG_RUN_CLOSED(dag_run_id=dag_run_id)]
+            ),
+        )
+        # SUNION has no ordering guarantee; ULIDs sort lexicographically by creation
+        # time, so sorting restores the submission-order guarantee callers rely on
+        # (e.g. the /dags/{dag_run_id} response) at no extra I/O cost.
+        task_ids = sorted(ULID.from_bytes(b) for b in raw_ids)
+        name_raw, status_raw = cast(
+            "list[bytes | None]",
+            await self.data_store.hmget(self.DAG_RUN_META(dag_run_id=dag_run_id), "name", "status"),
+        )
+        return DAGRunDetail(
+            dag_run_id=dag_run_id,
+            name=name_raw.decode() if name_raw else "",
+            status=DagRunStatus(status_raw.decode()) if status_raw else DagRunStatus.RUNNING,
+            submitted_at=submitted_at,
+            task_ids=task_ids,
+        )
+
+    async def clean_dag_runs(self, now: dt.datetime, max_age: dt.timedelta) -> None:
+        """Remove DAG run index entries and all their per-run structures older than ``max_age``."""
+        cutoff = (now - max_age).timestamp()
+        stale = cast("list[bytes]", await self.data_store.zrange(self.DAG_RUNS, "-inf", cutoff, byscore=True))
+        if not stale:
+            return
+        pipe = self.data_store.pipeline(transaction=False)
+        pipe.zrem(self.DAG_RUNS, *stale)
+        for dag_id_bytes in stale:
+            try:
+                dag_run_id = ULID.from_bytes(dag_id_bytes)
+            except ValueError:
+                continue
+            pipe.delete(self.DAG_RUN_PENDING(dag_run_id=dag_run_id))
+            pipe.delete(self.DAG_RUN_CLOSED(dag_run_id=dag_run_id))
+            pipe.delete(self.DAG_RUN_FANIN(dag_run_id=dag_run_id))
+            pipe.delete(self.DAG_RUN_FANIN_MEMBERS(dag_run_id=dag_run_id))
+            pipe.delete(self.DAG_RUN_META(dag_run_id=dag_run_id))
+        await pipe.execute()
+
+    async def record_dag_run_task_terminal(self, dag_run_id: ULID, outcome: DagRunOutcome) -> None:
+        """Atomically increment the run's completed/failed counters and recompute+persist status."""
+        await self._record_dag_run_terminal_script(
+            keys=[self.DAG_RUN_META(dag_run_id=dag_run_id)], args=[outcome]
+        )
+
+    async def mark_dag_run_complete(self, dag_run_id: ULID) -> None:
+        """Set status='complete' iff failed_count == 0. No-op if the run's record is missing."""
+        await self._mark_dag_run_complete_script(keys=[self.DAG_RUN_META(dag_run_id=dag_run_id)], args=[])

--- a/jobbers/adapters/redis/task_state.py
+++ b/jobbers/adapters/redis/task_state.py
@@ -239,6 +239,22 @@ class RedisTaskState(SharedTaskAdapterMixin):
             keys=[self.DAG_RUN_META(dag_run_id=dag_run_id)], args=[outcome]
         )
 
+    async def stage_record_dag_run_task_terminal(
+        self, pipe: TransactionHandle, dag_run_id: ULID, outcome: DagRunOutcome
+    ) -> None:
+        """
+        Stage record_dag_run_task_terminal onto pipe (part of AtomicDagRunProtocol).
+
+        Must be awaited: this only queues the EVALSHA command onto pipe, it does not
+        execute it (registered Lua scripts are coroutines under redis-py's async
+        client regardless of the target). The real result is only available in the
+        list returned by the eventual `await pipe.execute()`.
+        """
+        p: Any = pipe
+        await self._record_dag_run_terminal_script(
+            keys=[self.DAG_RUN_META(dag_run_id=dag_run_id)], args=[outcome], client=p
+        )
+
     async def mark_dag_run_complete(self, dag_run_id: ULID) -> None:
         """Set status='complete' iff failed_count == 0. No-op if the run's record is missing."""
         await self._mark_dag_run_complete_script(keys=[self.DAG_RUN_META(dag_run_id=dag_run_id)], args=[])

--- a/jobbers/adapters/redis/task_submit.py
+++ b/jobbers/adapters/redis/task_submit.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING
 from jobbers.adapters._shared import _SharedRedisTaskSubmitBase
 
 if TYPE_CHECKING:
-    from redis.asyncio.client import Redis
+    from redis.asyncio.client import Pipeline, Redis
 
     from jobbers.adapters.redis.task_state import RedisTaskState
     from jobbers.models.task import Task
@@ -31,6 +31,10 @@ _MSGPACK_SUBMIT_SCRIPT = """
     if ARGV[5] ~= '' then
         redis.call('ZADD', KEYS[4], 'NX', ARGV[1], ARGV[5])
         redis.call('SADD', KEYS[5], ARGV[2])
+        redis.call('HSETNX', KEYS[6], 'name', ARGV[6])
+        redis.call('HSETNX', KEYS[6], 'status', 'running')
+        redis.call('HSETNX', KEYS[6], 'completed', 0)
+        redis.call('HSETNX', KEYS[6], 'failed', 0)
     end
     return 1
 """
@@ -65,6 +69,10 @@ _MSGPACK_SUBMIT_RATE_LIMITED_SCRIPT = """
     if enqueued == 1 and ARGV[7] ~= '' then
         redis.call('ZADD', KEYS[5], 'NX', ARGV[3], ARGV[7])
         redis.call('SADD', KEYS[6], ARGV[4])
+        redis.call('HSETNX', KEYS[7], 'name', ARGV[8])
+        redis.call('HSETNX', KEYS[7], 'status', 'running')
+        redis.call('HSETNX', KEYS[7], 'completed', 0)
+        redis.call('HSETNX', KEYS[7], 'failed', 0)
     end
     return enqueued
 """
@@ -84,11 +92,13 @@ class RedisTaskSubmit(_SharedRedisTaskSubmitBase):
     # KEYS[3] = task-type-idx:{name}
     # KEYS[4] = dag-runs
     # KEYS[5] = dag-run:{dag_run_id}:pending (placeholder key when task has no DAG run)
+    # KEYS[6] = dag-run:{dag_run_id}:meta (placeholder key when task has no DAG run)
     # ARGV[1] = submitted_at timestamp
     # ARGV[2] = task_id bytes
     # ARGV[3] = '1'/'0' for type index
     # ARGV[4] = msgpack-encoded task blob
     # ARGV[5] = dag_run_id bytes (empty string if task is not part of a DAG run)
+    # ARGV[6] = dag_run_name (empty string if task is not part of a DAG run)
     SUBMIT_SCRIPT = _MSGPACK_SUBMIT_SCRIPT
 
     # Atomically check rate limit and enqueue.
@@ -98,6 +108,7 @@ class RedisTaskSubmit(_SharedRedisTaskSubmitBase):
     # KEYS[4] = task-type-idx:{name}
     # KEYS[5] = dag-runs
     # KEYS[6] = dag-run:{dag_run_id}:pending (placeholder key when task has no DAG run)
+    # KEYS[7] = dag-run:{dag_run_id}:meta (placeholder key when task has no DAG run)
     # ARGV[1] = earliest_time
     # ARGV[2] = rate_numerator
     # ARGV[3] = submitted_at timestamp
@@ -105,6 +116,7 @@ class RedisTaskSubmit(_SharedRedisTaskSubmitBase):
     # ARGV[5] = '1'/'0' for type index
     # ARGV[6] = msgpack-encoded task blob
     # ARGV[7] = dag_run_id bytes (empty string if task is not part of a DAG run)
+    # ARGV[8] = dag_run_name (empty string if task is not part of a DAG run)
     # Returns: 1 if enqueued, 0 if rate-limited
     SUBMIT_RATE_LIMITED_SCRIPT = _MSGPACK_SUBMIT_RATE_LIMITED_SCRIPT
 
@@ -113,8 +125,16 @@ class RedisTaskSubmit(_SharedRedisTaskSubmitBase):
 
     def _extra_submit_keys(self, task: Task) -> list[str]:
         dag_run_id = task.dag_run_id if task.dag_run_id is not None else ""
-        return [self.DAG_RUN_PENDING(dag_run_id=dag_run_id)]
+        return [self.DAG_RUN_PENDING(dag_run_id=dag_run_id), self.DAG_RUN_META(dag_run_id=dag_run_id)]
 
     def _extra_rate_limited_keys(self, task: Task) -> list[str]:
         dag_run_id = task.dag_run_id if task.dag_run_id is not None else ""
-        return [self.DAG_RUN_PENDING(dag_run_id=dag_run_id)]
+        return [self.DAG_RUN_PENDING(dag_run_id=dag_run_id), self.DAG_RUN_META(dag_run_id=dag_run_id)]
+
+    def _stage_dag_run_meta_seed(self, pipe: Pipeline, task: Task) -> None:
+        assert task.dag_run_id is not None  # noqa: S101
+        meta_key = self.DAG_RUN_META(dag_run_id=task.dag_run_id)
+        pipe.hsetnx(meta_key, "name", task.dag_run_name or "")
+        pipe.hsetnx(meta_key, "status", "running")
+        pipe.hsetnx(meta_key, "completed", 0)
+        pipe.hsetnx(meta_key, "failed", 0)

--- a/jobbers/adapters/redis_json/task_state.py
+++ b/jobbers/adapters/redis_json/task_state.py
@@ -25,10 +25,43 @@ from jobbers.adapters.redis_json._helpers import (
     _pack,
     _set_schema_version,
 )
+from jobbers.models.dag import DAGRunDetail, DagRunStatus, DAGRunSummary
 from jobbers.models.task import PaginationOrder, Task, TaskPagination
 
 if TYPE_CHECKING:
-    from redis.asyncio.client import Pipeline
+    from redis.asyncio.client import Pipeline, Redis
+
+    from jobbers.models.dag import DagRunOutcome, DAGRunPagination
+    from jobbers.protocols import TransactionHandle
+
+
+# Atomically increments the run's completed/failed field in its per-run JSON meta doc and
+# recomputes+persists the aggregate status. Returns 0 if the doc is missing (already
+# cleaned up), 1 otherwise. Never itself produces 'complete' -- that's written separately
+# by mark_dag_run_complete, gated on failed_count == 0.
+_RECORD_DAG_RUN_TERMINAL_SCRIPT = """
+    if redis.call('EXISTS', KEYS[1]) == 0 then return 0 end
+    local field = '$.failed'
+    if ARGV[1] == 'completed' then field = '$.completed' end
+    redis.call('JSON.NUMINCRBY', KEYS[1], field, 1)
+    local completed = cjson.decode(redis.call('JSON.GET', KEYS[1], '$.completed'))[1]
+    local failed = cjson.decode(redis.call('JSON.GET', KEYS[1], '$.failed'))[1]
+    local status = 'running'
+    if failed > 0 then
+        if completed > 0 then status = 'partial_failure' else status = 'failed' end
+    end
+    redis.call('JSON.SET', KEYS[1], '$.status', cjson.encode(status))
+    return 1
+"""
+
+# Sets status='complete' iff failed_count == 0. No-op (returns 0) if the doc is missing.
+# Idempotent: safe to call more than once, e.g. under concurrent last-completer races.
+_MARK_DAG_RUN_COMPLETE_SCRIPT = """
+    if redis.call('EXISTS', KEYS[1]) == 0 then return 0 end
+    local failed = cjson.decode(redis.call('JSON.GET', KEYS[1], '$.failed'))[1]
+    if failed == 0 then redis.call('JSON.SET', KEYS[1], '$.status', cjson.encode('complete')) end
+    return 1
+"""
 
 
 class RedisJSONTaskState(SharedTaskAdapterMixin):
@@ -41,6 +74,15 @@ class RedisJSONTaskState(SharedTaskAdapterMixin):
     SCHEMA_VERSION = 1
     INDEX_NAME = f"task-idx-v{SCHEMA_VERSION}"
     _VERSION_KEY = "schema_version:task_json"
+
+    DAG_RUNS = "dag-runs"
+    # JSON doc per run: {name, status, completed, failed}.
+    DAG_RUN_META = "dag-run:{dag_run_id}:meta".format
+
+    def __init__(self, data_store: Redis) -> None:
+        super().__init__(data_store)
+        self._record_dag_run_terminal_script = data_store.register_script(_RECORD_DAG_RUN_TERMINAL_SCRIPT)
+        self._mark_dag_run_complete_script = data_store.register_script(_MARK_DAG_RUN_COMPLETE_SCRIPT)
 
     # -- Storage primitives --------------------------------------------------
 
@@ -132,3 +174,107 @@ class RedisJSONTaskState(SharedTaskAdapterMixin):
         else:
             results.sort(key=lambda t: t.id)
         return results
+
+    # -- DAG run index --------------------------------------------------------
+
+    def stage_register_dag_run(self, pipe: TransactionHandle, task: Task) -> None:
+        """Stage DAG run index + metadata registration onto pipe if the task belongs to a DAG run."""
+        if task.dag_run_id is None or task.submitted_at is None:
+            return
+        score = task.submitted_at.timestamp()
+        p: Any = pipe
+        p.zadd(self.DAG_RUNS, {bytes(task.dag_run_id): score}, nx=True)
+        p.sadd(self.DAG_RUN_PENDING(dag_run_id=task.dag_run_id), bytes(task.id))
+        p.json().set(
+            self.DAG_RUN_META(dag_run_id=task.dag_run_id),
+            "$",
+            {
+                "name": task.dag_run_name or "",
+                "status": DagRunStatus.RUNNING.value,
+                "completed": 0,
+                "failed": 0,
+            },
+            nx=True,
+        )
+
+    async def get_dag_runs(self, pagination: DAGRunPagination) -> tuple[list[DAGRunSummary], int]:
+        """Return a paginated list of DAG runs ordered by submission time (oldest first)."""
+        total: int = await self.data_store.zcard(self.DAG_RUNS)
+        raw = cast(
+            "list[tuple[bytes, float]]",
+            await self.data_store.zrange(
+                self.DAG_RUNS, pagination.offset, pagination.offset + pagination.limit - 1, withscores=True
+            ),
+        )
+        pipe = self.data_store.pipeline(transaction=False)
+        for dag_id_bytes, _ in raw:
+            pipe.json().get(self.DAG_RUN_META(dag_run_id=ULID.from_bytes(dag_id_bytes)))
+        meta_docs = cast("list[dict[str, Any] | None]", await pipe.execute()) if raw else []
+        summaries = [
+            DAGRunSummary(
+                dag_run_id=ULID.from_bytes(dag_id_bytes),
+                name=(meta or {}).get("name", ""),
+                status=DagRunStatus((meta or {}).get("status", DagRunStatus.RUNNING.value)),
+                submitted_at=dt.datetime.fromtimestamp(score, dt.UTC),
+            )
+            for (dag_id_bytes, score), meta in zip(raw, meta_docs, strict=True)
+        ]
+        return summaries, total
+
+    async def get_dag_run(self, dag_run_id: ULID) -> DAGRunDetail | None:
+        """Return details for a DAG run via SUNION(pending, closed), or None if not registered."""
+        score: float | None = await self.data_store.zscore(self.DAG_RUNS, bytes(dag_run_id))
+        if score is None:
+            return None
+        submitted_at = dt.datetime.fromtimestamp(score, dt.UTC)
+        raw_ids = cast(
+            "set[bytes]",
+            await self.data_store.sunion(
+                [self.DAG_RUN_PENDING(dag_run_id=dag_run_id), self.DAG_RUN_CLOSED(dag_run_id=dag_run_id)]
+            ),
+        )
+        # SUNION has no ordering guarantee; ULIDs sort lexicographically by creation
+        # time, so sorting restores the submission-order guarantee callers rely on
+        # (e.g. the /dags/{dag_run_id} response) at no extra I/O cost.
+        task_ids = sorted(ULID.from_bytes(b) for b in raw_ids)
+        meta = cast(
+            "dict[str, Any] | None",
+            await self.data_store.json().get(self.DAG_RUN_META(dag_run_id=dag_run_id)),
+        )
+        return DAGRunDetail(
+            dag_run_id=dag_run_id,
+            name=(meta or {}).get("name", ""),
+            status=DagRunStatus((meta or {}).get("status", DagRunStatus.RUNNING.value)),
+            submitted_at=submitted_at,
+            task_ids=task_ids,
+        )
+
+    async def clean_dag_runs(self, now: dt.datetime, max_age: dt.timedelta) -> None:
+        """Remove DAG run index entries and all their per-run structures older than ``max_age``."""
+        cutoff = (now - max_age).timestamp()
+        stale = cast("list[bytes]", await self.data_store.zrange(self.DAG_RUNS, "-inf", cutoff, byscore=True))
+        if not stale:
+            return
+        pipe = self.data_store.pipeline(transaction=False)
+        pipe.zrem(self.DAG_RUNS, *stale)
+        for dag_id_bytes in stale:
+            try:
+                dag_run_id = ULID.from_bytes(dag_id_bytes)
+            except ValueError:
+                continue
+            pipe.delete(self.DAG_RUN_PENDING(dag_run_id=dag_run_id))
+            pipe.delete(self.DAG_RUN_CLOSED(dag_run_id=dag_run_id))
+            pipe.delete(self.DAG_RUN_FANIN(dag_run_id=dag_run_id))
+            pipe.delete(self.DAG_RUN_FANIN_MEMBERS(dag_run_id=dag_run_id))
+            pipe.delete(self.DAG_RUN_META(dag_run_id=dag_run_id))
+        await pipe.execute()
+
+    async def record_dag_run_task_terminal(self, dag_run_id: ULID, outcome: DagRunOutcome) -> None:
+        """Atomically increment the run's completed/failed counters and recompute+persist status."""
+        await self._record_dag_run_terminal_script(
+            keys=[self.DAG_RUN_META(dag_run_id=dag_run_id)], args=[outcome]
+        )
+
+    async def mark_dag_run_complete(self, dag_run_id: ULID) -> None:
+        """Set status='complete' iff failed_count == 0. No-op if the run's record is missing."""
+        await self._mark_dag_run_complete_script(keys=[self.DAG_RUN_META(dag_run_id=dag_run_id)], args=[])

--- a/jobbers/adapters/redis_json/task_state.py
+++ b/jobbers/adapters/redis_json/task_state.py
@@ -275,6 +275,22 @@ class RedisJSONTaskState(SharedTaskAdapterMixin):
             keys=[self.DAG_RUN_META(dag_run_id=dag_run_id)], args=[outcome]
         )
 
+    async def stage_record_dag_run_task_terminal(
+        self, pipe: TransactionHandle, dag_run_id: ULID, outcome: DagRunOutcome
+    ) -> None:
+        """
+        Stage record_dag_run_task_terminal onto pipe (part of AtomicDagRunProtocol).
+
+        Must be awaited: this only queues the EVALSHA command onto pipe, it does not
+        execute it (registered Lua scripts are coroutines under redis-py's async
+        client regardless of the target). The real result is only available in the
+        list returned by the eventual `await pipe.execute()`.
+        """
+        p: Any = pipe
+        await self._record_dag_run_terminal_script(
+            keys=[self.DAG_RUN_META(dag_run_id=dag_run_id)], args=[outcome], client=p
+        )
+
     async def mark_dag_run_complete(self, dag_run_id: ULID) -> None:
         """Set status='complete' iff failed_count == 0. No-op if the run's record is missing."""
         await self._mark_dag_run_complete_script(keys=[self.DAG_RUN_META(dag_run_id=dag_run_id)], args=[])

--- a/jobbers/adapters/redis_json/task_submit.py
+++ b/jobbers/adapters/redis_json/task_submit.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING
 from jobbers.adapters._shared import _SharedRedisTaskSubmitBase
 
 if TYPE_CHECKING:
-    from redis.asyncio.client import Redis
+    from redis.asyncio.client import Pipeline, Redis
 
     from jobbers.adapters.redis_json.task_state import RedisJSONTaskState
     from jobbers.models.task import Task
@@ -31,6 +31,7 @@ _JSON_SUBMIT_SCRIPT = """
     if ARGV[5] ~= '' then
         redis.call('ZADD', KEYS[4], 'NX', ARGV[1], ARGV[5])
         redis.call('SADD', KEYS[5], ARGV[2])
+        redis.call('JSON.SET', KEYS[6], '$', cjson.encode({name=ARGV[6], status='running', completed=0, failed=0}), 'NX')
     end
     return 1
 """
@@ -65,6 +66,7 @@ _JSON_SUBMIT_RATE_LIMITED_SCRIPT = """
     if enqueued == 1 and ARGV[7] ~= '' then
         redis.call('ZADD', KEYS[5], 'NX', ARGV[3], ARGV[7])
         redis.call('SADD', KEYS[6], ARGV[4])
+        redis.call('JSON.SET', KEYS[7], '$', cjson.encode({name=ARGV[8], status='running', completed=0, failed=0}), 'NX')
     end
     return enqueued
 """
@@ -84,11 +86,13 @@ class RedisJSONTaskSubmit(_SharedRedisTaskSubmitBase):
     # KEYS[3] = task-type-idx:{name}
     # KEYS[4] = dag-runs
     # KEYS[5] = dag-run:{dag_run_id}:pending (placeholder key when task has no DAG run)
+    # KEYS[6] = dag-run:{dag_run_id}:meta (placeholder key when task has no DAG run)
     # ARGV[1] = submitted_at timestamp
     # ARGV[2] = task_id bytes
     # ARGV[3] = '1' to SADD type index, '0' to SREM
     # ARGV[4] = JSON-encoded task blob
     # ARGV[5] = dag_run_id bytes (empty string if task is not part of a DAG run)
+    # ARGV[6] = dag_run_name (empty string if task is not part of a DAG run)
     SUBMIT_SCRIPT = _JSON_SUBMIT_SCRIPT
 
     # Atomically check rate limit and enqueue.
@@ -98,6 +102,7 @@ class RedisJSONTaskSubmit(_SharedRedisTaskSubmitBase):
     # KEYS[4] = task-type-idx:{name}
     # KEYS[5] = dag-runs
     # KEYS[6] = dag-run:{dag_run_id}:pending (placeholder key when task has no DAG run)
+    # KEYS[7] = dag-run:{dag_run_id}:meta (placeholder key when task has no DAG run)
     # ARGV[1] = earliest_time
     # ARGV[2] = rate_numerator
     # ARGV[3] = submitted_at timestamp
@@ -105,6 +110,7 @@ class RedisJSONTaskSubmit(_SharedRedisTaskSubmitBase):
     # ARGV[5] = '1'/'0' for type index
     # ARGV[6] = JSON-encoded task blob
     # ARGV[7] = dag_run_id bytes (empty string if task is not part of a DAG run)
+    # ARGV[8] = dag_run_name (empty string if task is not part of a DAG run)
     # Returns: 1 if enqueued, 0 if rate-limited
     SUBMIT_RATE_LIMITED_SCRIPT = _JSON_SUBMIT_RATE_LIMITED_SCRIPT
 
@@ -113,8 +119,17 @@ class RedisJSONTaskSubmit(_SharedRedisTaskSubmitBase):
 
     def _extra_submit_keys(self, task: Task) -> list[str]:
         dag_run_id = task.dag_run_id if task.dag_run_id is not None else ""
-        return [self.DAG_RUN_PENDING(dag_run_id=dag_run_id)]
+        return [self.DAG_RUN_PENDING(dag_run_id=dag_run_id), self.DAG_RUN_META(dag_run_id=dag_run_id)]
 
     def _extra_rate_limited_keys(self, task: Task) -> list[str]:
         dag_run_id = task.dag_run_id if task.dag_run_id is not None else ""
-        return [self.DAG_RUN_PENDING(dag_run_id=dag_run_id)]
+        return [self.DAG_RUN_PENDING(dag_run_id=dag_run_id), self.DAG_RUN_META(dag_run_id=dag_run_id)]
+
+    def _stage_dag_run_meta_seed(self, pipe: Pipeline, task: Task) -> None:
+        assert task.dag_run_id is not None  # noqa: S101
+        pipe.json().set(
+            self.DAG_RUN_META(dag_run_id=task.dag_run_id),
+            "$",
+            {"name": task.dag_run_name or "", "status": "running", "completed": 0, "failed": 0},
+            nx=True,
+        )

--- a/jobbers/adapters/sql/task_state.py
+++ b/jobbers/adapters/sql/task_state.py
@@ -26,6 +26,7 @@ from jobbers.migrations.schema import (
     task_queue,
     tasks,
 )
+from jobbers.models.dag import DAGRunDetail, DagRunStatus, DAGRunSummary
 from jobbers.models.task import PaginationOrder, Task, TaskPagination
 from jobbers.models.task_status import TaskStatus
 from jobbers.utils.sql_transaction import SQLTransactionBatch
@@ -35,7 +36,7 @@ if TYPE_CHECKING:
 
     from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-    from jobbers.models.dag import DAGRunPagination
+    from jobbers.models.dag import DagRunOutcome, DAGRunPagination
     from jobbers.protocols import TransactionHandle
 
 logger = logging.getLogger(__name__)
@@ -77,6 +78,15 @@ def _ensure_utc(d: dt.datetime | None) -> dt.datetime | None:
 def _ensure_utc_nn(d: dt.datetime) -> dt.datetime:
     """Non-nullable variant of _ensure_utc."""
     return d if d.tzinfo is not None else d.replace(tzinfo=dt.UTC)
+
+
+def _derive_dag_run_status(completed_count: int, failed_count: int) -> DagRunStatus:
+    """Derive aggregate status from a run's completed/failed counters (never returns COMPLETE)."""
+    if failed_count == 0:
+        return DagRunStatus.RUNNING
+    if completed_count > 0:
+        return DagRunStatus.PARTIAL_FAILURE
+    return DagRunStatus.FAILED
 
 
 def _row_to_task(row: Any) -> Task:
@@ -188,12 +198,20 @@ class SQLTaskState:
             dag_run_id_str = str(task.dag_run_id)
             submitted_at = task.submitted_at
             task_id_str = str(task.id)
+            dag_run_name = task.dag_run_name or ""
 
             async def _register_dag_run(s: AsyncSession) -> None:
                 existing = await s.execute(select(dag_runs).where(dag_runs.c.dag_run_id == dag_run_id_str))
                 if existing.first() is None:
                     await s.execute(
-                        insert(dag_runs).values(dag_run_id=dag_run_id_str, submitted_at=submitted_at)
+                        insert(dag_runs).values(
+                            dag_run_id=dag_run_id_str,
+                            submitted_at=submitted_at,
+                            name=dag_run_name,
+                            status=DagRunStatus.RUNNING.value,
+                            completed_count=0,
+                            failed_count=0,
+                        )
                     )
                 async with s.begin_nested() as sp:
                     try:
@@ -499,7 +517,7 @@ class SQLTaskState:
 
     # ── DAG run index ───────────────────────────────────────────────────────
 
-    async def get_dag_runs(self, pagination: DAGRunPagination) -> tuple[list[tuple[ULID, dt.datetime]], int]:
+    async def get_dag_runs(self, pagination: DAGRunPagination) -> tuple[list[DAGRunSummary], int]:
         """Return a paginated list of DAG runs ordered by submission time."""
         async with self._sf() as session:
             total_result = await session.execute(select(func.count()).select_from(dag_runs))
@@ -511,12 +529,18 @@ class SQLTaskState:
                 .offset(pagination.offset)
             )
             entries = [
-                (ULID.from_str(row.dag_run_id), _ensure_utc_nn(row.submitted_at)) for row in result.all()
+                DAGRunSummary(
+                    dag_run_id=ULID.from_str(row.dag_run_id),
+                    name=row.name,
+                    status=DagRunStatus(row.status),
+                    submitted_at=_ensure_utc_nn(row.submitted_at),
+                )
+                for row in result.all()
             ]
         return entries, total
 
-    async def get_dag_run(self, dag_run_id: ULID) -> tuple[dt.datetime, list[ULID]] | None:
-        """Return (submitted_at, task_ids) for a DAG run, or None."""
+    async def get_dag_run(self, dag_run_id: ULID) -> DAGRunDetail | None:
+        """Return DAGRunDetail for a DAG run, or None."""
         dag_run_id_str = str(dag_run_id)
         async with self._sf() as session:
             run_result = await session.execute(
@@ -531,7 +555,13 @@ class SQLTaskState:
             # ULIDs sort lexicographically by creation time; sort here so task_ids
             # is chronologically ordered regardless of the row order SQL returns.
             task_ids = sorted(ULID.from_str(row.id) for row in task_result.all())
-        return _ensure_utc_nn(run_row.submitted_at), task_ids
+        return DAGRunDetail(
+            dag_run_id=dag_run_id,
+            name=run_row.name,
+            status=DagRunStatus(run_row.status),
+            submitted_at=_ensure_utc_nn(run_row.submitted_at),
+            task_ids=task_ids,
+        )
 
     async def clean_dag_runs(self, now: dt.datetime, max_age: dt.timedelta) -> None:
         """Delete DAG run entries (and their pending rows) older than ``max_age``."""
@@ -592,6 +622,53 @@ class SQLTaskState:
                     )
                 )
                 return count_result.scalar() or 0
+
+    async def record_dag_run_task_terminal(self, dag_run_id: ULID, outcome: DagRunOutcome) -> None:
+        """Atomically increment the run's completed/failed counters and recompute+persist status."""
+        dag_run_id_str = str(dag_run_id)
+        async with self._sf() as session:
+            async with session.begin():
+                lock_stmt = select(dag_runs.c.dag_run_id).where(dag_runs.c.dag_run_id == dag_run_id_str)
+                if self._use_for_update:
+                    lock_stmt = lock_stmt.with_for_update()
+                if (await session.execute(lock_stmt)).first() is None:
+                    return  # run record missing (already cleaned up) -- no-op
+                col = dag_runs.c.failed_count if outcome == "failed" else dag_runs.c.completed_count
+                await session.execute(
+                    update(dag_runs)
+                    .where(dag_runs.c.dag_run_id == dag_run_id_str)
+                    .values({col.name: col + 1})
+                )
+                counts = (
+                    await session.execute(
+                        select(dag_runs.c.completed_count, dag_runs.c.failed_count).where(
+                            dag_runs.c.dag_run_id == dag_run_id_str
+                        )
+                    )
+                ).first()
+                assert counts is not None  # noqa: S101
+                new_status = _derive_dag_run_status(counts.completed_count, counts.failed_count)
+                await session.execute(
+                    update(dag_runs)
+                    .where(dag_runs.c.dag_run_id == dag_run_id_str)
+                    .values(status=new_status.value)
+                )
+
+    async def mark_dag_run_complete(self, dag_run_id: ULID) -> None:
+        """Set status='complete' iff failed_count == 0. No-op if the run's record is missing."""
+        dag_run_id_str = str(dag_run_id)
+        async with self._sf() as session:
+            async with session.begin():
+                lock_stmt = select(dag_runs.c.dag_run_id).where(dag_runs.c.dag_run_id == dag_run_id_str)
+                if self._use_for_update:
+                    lock_stmt = lock_stmt.with_for_update()
+                if (await session.execute(lock_stmt)).first() is None:
+                    return
+                await session.execute(
+                    update(dag_runs)
+                    .where(dag_runs.c.dag_run_id == dag_run_id_str, dag_runs.c.failed_count == 0)
+                    .values(status=DagRunStatus.COMPLETE.value)
+                )
 
     # ── Lifecycle ───────────────────────────────────────────────────────────
 

--- a/jobbers/adapters/sql/task_state.py
+++ b/jobbers/adapters/sql/task_state.py
@@ -14,7 +14,7 @@ import json
 import logging
 from typing import TYPE_CHECKING, Any
 
-from sqlalchemy import delete, func, insert, select, update
+from sqlalchemy import case, delete, func, insert, select, update
 from sqlalchemy.exc import IntegrityError
 from ulid import ULID
 
@@ -78,15 +78,6 @@ def _ensure_utc(d: dt.datetime | None) -> dt.datetime | None:
 def _ensure_utc_nn(d: dt.datetime) -> dt.datetime:
     """Non-nullable variant of _ensure_utc."""
     return d if d.tzinfo is not None else d.replace(tzinfo=dt.UTC)
-
-
-def _derive_dag_run_status(completed_count: int, failed_count: int) -> DagRunStatus:
-    """Derive aggregate status from a run's completed/failed counters (never returns COMPLETE)."""
-    if failed_count == 0:
-        return DagRunStatus.RUNNING
-    if completed_count > 0:
-        return DagRunStatus.PARTIAL_FAILURE
-    return DagRunStatus.FAILED
 
 
 def _row_to_task(row: Any) -> Task:
@@ -624,46 +615,47 @@ class SQLTaskState:
                 return count_result.scalar() or 0
 
     async def record_dag_run_task_terminal(self, dag_run_id: ULID, outcome: DagRunOutcome) -> None:
-        """Atomically increment the run's completed/failed counters and recompute+persist status."""
+        """
+        Atomically increment the run's completed/failed counters and recompute+persist status.
+
+        A single UPDATE does the increment, status recompute, and write together.
+        SET-clause column references (``dag_runs.c.completed_count`` etc.) are
+        evaluated against the row's pre-statement values under standard SQL UPDATE
+        semantics, and Postgres takes an implicit row lock for the statement's
+        duration -- concurrent calls for the same run serialize on that lock and
+        each sees the other's committed increment, the same guarantee the previous
+        explicit ``SELECT ... FOR UPDATE`` provided, without a separate round trip
+        for it. No-op (matches 0 rows) if the run's record is missing.
+        """
         dag_run_id_str = str(dag_run_id)
+        new_completed = dag_runs.c.completed_count + (1 if outcome == "completed" else 0)
+        new_failed = dag_runs.c.failed_count + (1 if outcome == "failed" else 0)
         async with self._sf() as session:
             async with session.begin():
-                lock_stmt = select(dag_runs.c.dag_run_id).where(dag_runs.c.dag_run_id == dag_run_id_str)
-                if self._use_for_update:
-                    lock_stmt = lock_stmt.with_for_update()
-                if (await session.execute(lock_stmt)).first() is None:
-                    return  # run record missing (already cleaned up) -- no-op
-                col = dag_runs.c.failed_count if outcome == "failed" else dag_runs.c.completed_count
                 await session.execute(
                     update(dag_runs)
                     .where(dag_runs.c.dag_run_id == dag_run_id_str)
-                    .values({col.name: col + 1})
-                )
-                counts = (
-                    await session.execute(
-                        select(dag_runs.c.completed_count, dag_runs.c.failed_count).where(
-                            dag_runs.c.dag_run_id == dag_run_id_str
-                        )
+                    .values(
+                        completed_count=new_completed,
+                        failed_count=new_failed,
+                        status=case(
+                            (new_failed == 0, DagRunStatus.RUNNING.value),
+                            (new_completed > 0, DagRunStatus.PARTIAL_FAILURE.value),
+                            else_=DagRunStatus.FAILED.value,
+                        ),
                     )
-                ).first()
-                assert counts is not None  # noqa: S101
-                new_status = _derive_dag_run_status(counts.completed_count, counts.failed_count)
-                await session.execute(
-                    update(dag_runs)
-                    .where(dag_runs.c.dag_run_id == dag_run_id_str)
-                    .values(status=new_status.value)
                 )
 
     async def mark_dag_run_complete(self, dag_run_id: ULID) -> None:
-        """Set status='complete' iff failed_count == 0. No-op if the run's record is missing."""
+        """
+        Set status='complete' iff failed_count == 0. No-op if the run's record is missing.
+
+        A single conditional UPDATE (see record_dag_run_task_terminal's docstring for
+        why the row lock from a bare UPDATE is sufficient here too).
+        """
         dag_run_id_str = str(dag_run_id)
         async with self._sf() as session:
             async with session.begin():
-                lock_stmt = select(dag_runs.c.dag_run_id).where(dag_runs.c.dag_run_id == dag_run_id_str)
-                if self._use_for_update:
-                    lock_stmt = lock_stmt.with_for_update()
-                if (await session.execute(lock_stmt)).first() is None:
-                    return
                 await session.execute(
                     update(dag_runs)
                     .where(dag_runs.c.dag_run_id == dag_run_id_str, dag_runs.c.failed_count == 0)

--- a/jobbers/adapters/sql/task_submit.py
+++ b/jobbers/adapters/sql/task_submit.py
@@ -21,6 +21,7 @@ from jobbers.migrations.schema import (
     task_queue,
     tasks,
 )
+from jobbers.models.dag import DagRunStatus
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
@@ -44,7 +45,14 @@ async def _register_dag_run(session: AsyncSession, task: Task) -> None:
     existing = await session.execute(select(dag_runs).where(dag_runs.c.dag_run_id == dag_run_id_str))
     if existing.first() is None:
         await session.execute(
-            insert(dag_runs).values(dag_run_id=dag_run_id_str, submitted_at=task.submitted_at)
+            insert(dag_runs).values(
+                dag_run_id=dag_run_id_str,
+                submitted_at=task.submitted_at,
+                name=task.dag_run_name or "",
+                status=DagRunStatus.RUNNING.value,
+                completed_count=0,
+                failed_count=0,
+            )
         )
     async with session.begin_nested() as sp:
         try:

--- a/jobbers/migrations/schema.py
+++ b/jobbers/migrations/schema.py
@@ -135,6 +135,10 @@ dag_runs = Table(
     metadata,
     Column("dag_run_id", String(26), primary_key=True),
     Column("submitted_at", DateTime(timezone=True), nullable=False),
+    Column("name", String, nullable=False, server_default=""),
+    Column("status", String, nullable=False, server_default="running"),
+    Column("completed_count", Integer, nullable=False, server_default="0"),
+    Column("failed_count", Integer, nullable=False, server_default="0"),
 )
 
 Index("idx_dag_runs_submitted", dag_runs.c.submitted_at)

--- a/jobbers/models/dag.py
+++ b/jobbers/models/dag.py
@@ -57,7 +57,9 @@ own `then()` chain if further steps are needed on failure.
 
 from __future__ import annotations
 
+import datetime as dt  # noqa: TC003 -- resolved at runtime by Pydantic (DAGRunSummary.submitted_at)
 from dataclasses import dataclass, field
+from enum import StrEnum
 from typing import TYPE_CHECKING, Annotated, Any, Literal
 
 from pydantic import BaseModel, Field, field_serializer
@@ -417,7 +419,13 @@ class DAGNode:
         callbacks.extend(self._fanout_callbacks)
         return callbacks
 
-    def to_task(self, *, parent_id: ULID | None = None, dag_run_id: ULID | None = None) -> Task:
+    def to_task(
+        self,
+        *,
+        parent_id: ULID | None = None,
+        dag_run_id: ULID | None = None,
+        dag_run_name: str | None = None,
+    ) -> Task:
         """Return a `Task` for this node ready for submission."""
         from jobbers.models.task import Task
 
@@ -430,6 +438,7 @@ class DAGNode:
             dag_callbacks=self._callbacks_recursive(),
             parent_ids=[parent_id] if parent_id is not None else [],
             dag_run_id=dag_run_id,
+            dag_run_name=dag_run_name,
         )
 
     def fan_in_predecessors(self) -> dict[str, set[ULID]]:
@@ -540,6 +549,44 @@ class DAGRunPagination(BaseModel):
 
     limit: int = Field(default=50, gt=0, le=100)
     offset: int = Field(default=0, ge=0)
+
+
+class DagRunStatus(StrEnum):
+    """Aggregate status of a DAG run, derived from its tasks' terminal outcomes."""
+
+    RUNNING = "running"
+    COMPLETE = "complete"
+    PARTIAL_FAILURE = "partial_failure"
+    FAILED = "failed"
+
+
+# Outcome recorded against a run's aggregate counters when one of its tasks reaches a
+# terminal status -- "completed" for TaskStatus.COMPLETED, "failed" for any status in
+# TaskStatus.stuck_statuses() (FAILED/STALLED/CANCELLED/DROPPED).
+DagRunOutcome = Literal["completed", "failed"]
+
+
+class DAGRunSummary(BaseModel):
+    """One row of a DAG run listing: identity, name, status, submission time."""
+
+    dag_run_id: ULID
+    name: str
+    status: DagRunStatus
+    submitted_at: dt.datetime
+
+    @field_serializer("dag_run_id", when_used="json")
+    def serialize_dag_run_id(self, value: ULID) -> str:
+        return str(value)
+
+
+class DAGRunDetail(DAGRunSummary):
+    """DAGRunSummary plus the full list of task IDs belonging to the run."""
+
+    task_ids: list[ULID]
+
+    @field_serializer("task_ids", when_used="json")
+    def serialize_task_ids(self, value: list[ULID]) -> list[str]:
+        return [str(v) for v in value]
 
 
 # Avoid circular import at module level – Task is only referenced inside methods.

--- a/jobbers/models/task.py
+++ b/jobbers/models/task.py
@@ -83,6 +83,13 @@ class Task(BaseModel):
     # Generated once at submission time (submit_dag / dispatch_cron_dag) and propagated to all
     # descendants via generate_callbacks, generate_error_callbacks, and _handle_dynamic_fanout.
     dag_run_id: OptionalULIDField = Field(default=None)
+    # Human-readable name of the DAG run, set once alongside dag_run_id by whichever call
+    # site mints it (StateManager.submit_dag, StateManager._dispatch_cron_dag_locked,
+    # TaskProcessor._handle_dynamic_fanout's self-started-run case) and propagated unchanged
+    # to every descendant the same way dag_run_id is. Always resolved to a concrete
+    # non-empty string by that call site — never left as a bare None. Non-None whenever
+    # dag_run_id is non-None.
+    dag_run_name: str | None = Field(default=None)
 
     @field_serializer("id", when_used="json")
     def serialize_id(self, value: ULID) -> str:
@@ -206,6 +213,7 @@ class Task(BaseModel):
             parent_ids=parent_ids,
             inject_parent_results=inject_parent_results,
             dag_run_id=self.dag_run_id,
+            dag_run_name=self.dag_run_name,
         )
 
     def generate_error_callbacks(self) -> list[Self]:

--- a/jobbers/protocols.py
+++ b/jobbers/protocols.py
@@ -20,6 +20,8 @@ Task storage / dead-letter queue (split-store protocols):
 - `AtomicTaskSchedulerProtocol` — extends TaskSchedulerProtocol with pipeline staging.
 - `AtomicDeadQueueProtocol` — extends DeadQueueProtocol with pipeline staging.
 - `AtomicCronDAGSchedulerProtocol` — extends CronDAGSchedulerProtocol with pipeline staging.
+- `AtomicDagRunProtocol` — optional additive capability: fold DAG-run-terminal
+  bookkeeping into the same pipeline as close_dag_run_task (Redis/RedisJSON only).
 - `DeadQueueProtocol` — interface all dead-letter queue implementations must implement.
 """
 
@@ -431,6 +433,44 @@ class AtomicDeadQueueProtocol(DeadQueueProtocol, Protocol):  # pragma: no cover
     def backend_key(self) -> str: ...
 
     def pipeline(self, transaction: bool = True) -> TransactionHandle: ...
+
+
+@runtime_checkable
+class AtomicDagRunProtocol(Protocol):  # pragma: no cover
+    """
+    Optional additive capability, checked independently of AtomicTaskStateProtocol.
+
+    Lets StateManager fold record_dag_run_task_terminal + close_dag_run_task into a
+    single pipelined round trip instead of two separate EVALSHA calls.
+
+    Not part of AtomicTaskStateProtocol itself -- an adapter can be atomic-pipeline-
+    eligible (stage_save, stage_requeue, etc.) without implementing this. SQL's
+    record_dag_run_task_terminal is already a single UPDATE with no separate round
+    trip to fold away, so SQLTaskState has no reason to implement it; only
+    RedisTaskState/RedisJSONTaskState do.
+    """
+
+    def pipeline(self, transaction: bool = True) -> TransactionHandle: ...
+
+    async def stage_record_dag_run_task_terminal(
+        self, pipe: TransactionHandle, dag_run_id: ULID, outcome: DagRunOutcome
+    ) -> None:
+        """
+        Stage the counter-increment + status recompute onto pipe.
+
+        Must be awaited even though it only queues a command onto pipe and performs
+        no I/O of its own: registered Lua scripts (redis-py's AsyncScript) are
+        coroutines regardless of whether `client` is the live connection or a
+        pipeline. The actual result is only available in the list returned by
+        `await pipe.execute()`.
+        """
+        ...
+
+    async def stage_close_dag_run_task(
+        self, pipe: TransactionHandle, dag_run_id: ULID, task_id: ULID
+    ) -> None:
+        """Stage close_dag_run_task's SREM/SADD/SCARD move onto pipe (see stage_record_dag_run_task_terminal)."""
+        ...
 
 
 class CronDAGSchedulerProtocol(Protocol):  # pragma: no cover

--- a/jobbers/protocols.py
+++ b/jobbers/protocols.py
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
     from ulid import ULID
 
     from jobbers.models.cron_dag import CronDAGEntry
-    from jobbers.models.dag import DAGRunPagination
+    from jobbers.models.dag import DAGRunDetail, DagRunOutcome, DAGRunPagination, DAGRunSummary
     from jobbers.models.queue_config import QueueConfig
     from jobbers.models.task import Task, TaskPagination
     from jobbers.models.task_routing import RoutingConfig
@@ -271,10 +271,8 @@ class TaskStateProtocol(Protocol):  # pragma: no cover
         ...
 
     # DAG run index
-    async def get_dag_runs(
-        self, pagination: DAGRunPagination
-    ) -> tuple[list[tuple[ULID, dt.datetime]], int]: ...
-    async def get_dag_run(self, dag_run_id: ULID) -> tuple[dt.datetime, list[ULID]] | None: ...
+    async def get_dag_runs(self, pagination: DAGRunPagination) -> tuple[list[DAGRunSummary], int]: ...
+    async def get_dag_run(self, dag_run_id: ULID) -> DAGRunDetail | None: ...
     async def clean_dag_runs(self, now: dt.datetime, max_age: dt.timedelta) -> None: ...
     async def close_dag_run_task(self, dag_run_id: ULID, task_id: ULID) -> int:
         """
@@ -284,6 +282,16 @@ class TaskStateProtocol(Protocol):  # pragma: no cover
         key/rows expired) — callers must treat -1 as "do not trigger the sweep",
         exactly like fan_in_complete's -1 sentinel.
         """
+        ...
+
+    # DAG run aggregate status — wholly additive to the pending/closed mechanism above;
+    # neither of these reads or writes DAG_RUN_PENDING/DAG_RUN_CLOSED state.
+    async def record_dag_run_task_terminal(self, dag_run_id: ULID, outcome: DagRunOutcome) -> None:
+        """Atomically increment the run's completed/failed counters and recompute+persist status."""
+        ...
+
+    async def mark_dag_run_complete(self, dag_run_id: ULID) -> None:
+        """Set status='complete' iff failed_count == 0. No-op if the run's record is missing."""
         ...
 
     # Lifecycle

--- a/jobbers/state_manager.py
+++ b/jobbers/state_manager.py
@@ -7,7 +7,7 @@ import random
 from collections import defaultdict
 from contextlib import asynccontextmanager, contextmanager
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from croniter import croniter
 from opentelemetry import metrics
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
     from jobbers.models.task_routing import RoutingConfig
     from jobbers.protocols import (
         AtomicCronDAGSchedulerProtocol,
+        AtomicDagRunProtocol,
         AtomicDeadQueueProtocol,
         AtomicTaskSchedulerProtocol,
         AtomicTaskStateProtocol,
@@ -123,6 +124,7 @@ class StateManager:
         # when force_saga=True, it falls back to saga coordination.
         from jobbers.protocols import (  # local import avoids circular at module level
             AtomicCronDAGSchedulerProtocol,
+            AtomicDagRunProtocol,
             AtomicDeadQueueProtocol,
             AtomicTaskSchedulerProtocol,
             AtomicTaskStateProtocol,
@@ -153,6 +155,17 @@ class StateManager:
                 and self._atomic_state is not None
                 and cron_dag_scheduler.backend_key == self._atomic_state.backend_key
             )
+            else None
+        )
+        # DAG-run-terminal-specific: True when the task-state adapter can fold
+        # record_dag_run_task_terminal + close_dag_run_task into one pipelined round
+        # trip (Redis/RedisJSON). Checked independently of _atomic_mode -- a backend
+        # without this (e.g. SQL) still gets full atomic-mode pipelining for
+        # everything else, it just doesn't have a "same pipeline" concept for these
+        # two calls to fold into.
+        self._atomic_dag_run: AtomicDagRunProtocol | None = (
+            self._atomic_state
+            if (not force_saga and isinstance(self._atomic_state, AtomicDagRunProtocol))
             else None
         )
 
@@ -979,13 +992,72 @@ class StateManager:
         """Return details for a DAG run, or None if not found."""
         return await self.task_state.get_dag_run(dag_run_id)
 
+    async def finalize_dag_run_task(self, task: Task) -> None:
+        """
+        Record *task*'s terminal outcome, close it out of its run's pending set, and sweep.
+
+        This is the single entry point TaskProcessor calls per DAG-task completion
+        (any terminal status). It owns the ordering between the two steps so callers
+        don't have to reproduce it: record_dag_run_task_terminal's recompute
+        unconditionally rewrites status to running/partial_failure/failed (never
+        complete), so running it *after* mark_dag_run_complete on the run's last task
+        would immediately clobber that 'complete' write back to a non-terminal
+        status. Calling record first for every task, and only ever calling
+        mark_dag_run_complete afterwards, means the 'complete' write is always the
+        last one to happen for a given task — and since pending only reaches zero
+        once every sibling's own close has already run (each preceded by its own
+        record call, in-order within that sibling's coroutine), every sibling's
+        record call is guaranteed to have already posted by the time the run's
+        pending count reaches zero, regardless of how concurrent completions
+        interleave.
+
+        A DAG task in a stuck status (``TaskStatus.stuck_statuses()`` — FAILED,
+        STALLED, CANCELLED, or DROPPED) never closes out of the pending counter: such
+        a task never calls ``generate_callbacks()``, so its ``FanInCallback``/
+        ``DynamicFanOutCallback`` never fires and the DAG can't complete on its own.
+        Leaving the counter open preserves the run's fan-in tracking and sibling task
+        records (within their TTLs) instead of sweeping them away.
+
+        When the task-state adapter implements ``AtomicDagRunProtocol`` (Redis/
+        RedisJSON), the record + close steps for non-stuck tasks are folded into one
+        pipelined round trip instead of two sequential ones.
+        """
+        assert task.dag_run_id is not None  # noqa: S101
+        if task.status in TaskStatus.stuck_statuses():
+            await self.record_dag_run_task_terminal(task)
+            return
+        if self._atomic_dag_run is None:
+            await self.record_dag_run_task_terminal(task)
+            await self.close_dag_run_task_and_sweep(task)
+            return
+        remaining = await self._record_terminal_and_close_atomic(task)
+        await self._finish_dag_run_if_terminal(task, remaining)
+
+    async def _record_terminal_and_close_atomic(self, task: Task) -> int:
+        """
+        Fold record_dag_run_task_terminal + close_dag_run_task into one pipelined round trip.
+
+        Only called from finalize_dag_run_task for non-stuck tasks, so outcome is
+        always 'completed' here (stuck tasks return before reaching this path).
+        """
+        assert task.dag_run_id is not None  # noqa: S101
+        assert self._atomic_dag_run is not None  # noqa: S101
+        pipe = self._atomic_dag_run.pipeline(transaction=True)
+        await self._atomic_dag_run.stage_record_dag_run_task_terminal(pipe, task.dag_run_id, "completed")
+        await self._atomic_dag_run.stage_close_dag_run_task(pipe, task.dag_run_id, task.id)
+        results = await pipe.execute()
+        close_result = cast("list[int]", results[-1])
+        return int(close_result[1])
+
     async def record_dag_run_task_terminal(self, task: Task) -> None:
         """
         Record *task*'s terminal outcome against its run's aggregate status counters.
 
         Wholly additive: does not read or write DAG_RUN_PENDING/CLOSED. Called once
         per terminal DAG task for every terminal status (unlike close_dag_run_task_
-        and_sweep, which only fires for non-stuck statuses).
+        and_sweep, which only fires for non-stuck statuses). Prefer
+        ``finalize_dag_run_task`` at call sites — it owns the ordering between this
+        and ``close_dag_run_task_and_sweep``.
         """
         assert task.dag_run_id is not None  # noqa: S101
         outcome: DagRunOutcome = "failed" if task.status in TaskStatus.stuck_statuses() else "completed"
@@ -1013,8 +1085,9 @@ class StateManager:
         the run's index is orphaned, cannot — re-verify that on its own; passing
         *fallback_task* for a run that still has siblings in flight would delete a
         task those siblings may still depend on (e.g. via ``parent_results()``).
-        The only production caller, ``close_dag_run_task_and_sweep``, already
-        guarantees this.
+        The only production caller, ``_finish_dag_run_if_terminal`` (via either
+        ``close_dag_run_task_and_sweep`` or ``finalize_dag_run_task``'s pipelined
+        path), already guarantees this.
         """
         run = await self.get_dag_run(dag_run_id)
         if run is None:
@@ -1042,14 +1115,24 @@ class StateManager:
         Only called for tasks reaching a non-stuck terminal status (see
         ``TaskProcessor._maybe_cleanup``) — FAILED/STALLED/CANCELLED/DROPPED tasks never
         close out of ``DAG_RUN_PENDING`` at all, so a run containing one simply never
-        reaches a pending count of zero and this method is never invoked for it. Since
-        only ``COMPLETED`` tasks ever reach here, reaching a pending count of zero means
-        every task the run has ever registered completed successfully -- so this also
-        marks the run's aggregate status ``complete`` (via ``mark_dag_run_complete``,
-        itself gated on the run having never recorded a failed task, defensively).
+        reaches a pending count of zero and this method is never invoked for it.
         """
         assert task.dag_run_id is not None  # noqa: S101
         remaining = await self.close_dag_run_task(task.dag_run_id, task.id)
+        await self._finish_dag_run_if_terminal(task, remaining)
+
+    async def _finish_dag_run_if_terminal(self, task: Task, remaining: int) -> None:
+        """
+        Mark the run complete and sweep siblings once *remaining* hits 0.
+
+        *remaining* comes from close_dag_run_task, staged or not. Since only
+        ``COMPLETED`` tasks ever reach here, reaching a pending count of
+        zero means every task the run has ever registered completed successfully --
+        so this also marks the run's aggregate status ``complete`` (via
+        ``mark_dag_run_complete``, itself gated on the run having never recorded a
+        failed task, defensively).
+        """
+        assert task.dag_run_id is not None  # noqa: S101
         if remaining != 0:
             # >0: DAG still in flight, the last task to close will trigger the sweep.
             # -1: already closed (duplicate call) or the run's pending entry expired/was

--- a/jobbers/state_manager.py
+++ b/jobbers/state_manager.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Awaitable, Callable, Iterator
 
     from jobbers.models.cron_dag import CronDAGEntry
-    from jobbers.models.dag import DAGNode, DAGRunPagination
+    from jobbers.models.dag import DAGNode, DAGRunDetail, DagRunOutcome, DAGRunPagination, DAGRunSummary
     from jobbers.models.queue_config import QueueConfig
     from jobbers.models.task_routing import RoutingConfig
     from jobbers.protocols import (
@@ -523,6 +523,7 @@ class StateManager:
                 dag_callbacks=fresh_spec.dag_callbacks,
                 cron_id=entry.id,
                 dag_run_id=dag_run_id,
+                dag_run_name=f"{entry.name} @ {run_at.isoformat()}",
             )
 
             is_rate_limited = bool(
@@ -938,36 +939,61 @@ class StateManager:
         await self.cron_dag_scheduler.remove(cron_id)
         logger.info("Cron DAG entry %s removed.", cron_id)
 
-    async def submit_dag(self, *roots: DAGNode) -> tuple[ULID, list[Task]]:
+    async def submit_dag(
+        self, *roots: DAGNode, name: str, dag_run_id: ULID | None = None
+    ) -> tuple[ULID, list[Task]]:
         """
         Initialise fan-in sets and submit all root tasks of a DAG.
 
         All fan-in Redis sets are populated *before* any task is enqueued so
         that a fast-completing predecessor cannot decrement a set that does not
         yet exist.
+
+        `name` is required here — callers must resolve any user-facing default
+        (e.g. `jobbers/task_routes.py`'s `submit_dag` route defaults an omitted
+        name to `str(dag_run_id)`) before calling this method. `dag_run_id` is an
+        optional override so a caller that needs to know the ID in advance (in
+        order to build that default) can supply it; every other caller lets this
+        method self-generate one exactly as before.
         """
         all_fan_ins: dict[str, set[ULID]] = {}
         for root in roots:
             for key, ids in root.fan_in_predecessors().items():
                 all_fan_ins.setdefault(key, set()).update(ids)
 
-        dag_run_id = ULID()
+        dag_run_id = dag_run_id or ULID()
         await asyncio.gather(*(self.init_fan_in(dag_run_id, k, ids) for k, ids in all_fan_ins.items()))
 
         submitted: list[Task] = []
         for root in roots:
-            task = root.to_task(dag_run_id=dag_run_id)
+            task = root.to_task(dag_run_id=dag_run_id, dag_run_name=name)
             await self.submit_task(task)
             submitted.append(task)
         return dag_run_id, submitted
 
-    async def list_dag_runs(self, pagination: DAGRunPagination) -> tuple[list[tuple[ULID, dt.datetime]], int]:
+    async def list_dag_runs(self, pagination: DAGRunPagination) -> tuple[list[DAGRunSummary], int]:
         """Return a paginated list of DAG runs ordered by submission time."""
         return await self.task_state.get_dag_runs(pagination)
 
-    async def get_dag_run(self, dag_run_id: ULID) -> tuple[dt.datetime, list[ULID]] | None:
-        """Return (submitted_at, task_ids) for a DAG run, or None if not found."""
+    async def get_dag_run(self, dag_run_id: ULID) -> DAGRunDetail | None:
+        """Return details for a DAG run, or None if not found."""
         return await self.task_state.get_dag_run(dag_run_id)
+
+    async def record_dag_run_task_terminal(self, task: Task) -> None:
+        """
+        Record *task*'s terminal outcome against its run's aggregate status counters.
+
+        Wholly additive: does not read or write DAG_RUN_PENDING/CLOSED. Called once
+        per terminal DAG task for every terminal status (unlike close_dag_run_task_
+        and_sweep, which only fires for non-stuck statuses).
+        """
+        assert task.dag_run_id is not None  # noqa: S101
+        outcome: DagRunOutcome = "failed" if task.status in TaskStatus.stuck_statuses() else "completed"
+        await self.task_state.record_dag_run_task_terminal(task.dag_run_id, outcome)
+
+    async def mark_dag_run_complete(self, dag_run_id: ULID) -> None:
+        """Set the run's status to complete iff it has never recorded a failed task."""
+        await self.task_state.mark_dag_run_complete(dag_run_id)
 
     async def close_dag_run_task(self, dag_run_id: ULID, task_id: ULID) -> int:
         """Mark task_id resolved in the DAG run's pending set; return the remaining count."""
@@ -998,8 +1024,7 @@ class StateManager:
                     await self.delete_task(fallback_task)
             return
 
-        _, task_ids = run
-        sibling_tasks = await self.task_state.get_tasks_bulk(task_ids)
+        sibling_tasks = await self.task_state.get_tasks_bulk(run.task_ids)
         to_delete: list[Task] = []
         for sibling in sibling_tasks:
             if sibling is None:
@@ -1015,9 +1040,13 @@ class StateManager:
         Close *task* out of its DAG run's pending set and sweep siblings if the run just went terminal.
 
         Only called for tasks reaching a non-stuck terminal status (see
-        ``TaskProcessor._maybe_cleanup``) — FAILED/STALLED tasks never close out of
-        ``DAG_RUN_PENDING`` at all, so a run containing one simply never reaches a
-        pending count of zero and this method is never invoked for it.
+        ``TaskProcessor._maybe_cleanup``) — FAILED/STALLED/CANCELLED/DROPPED tasks never
+        close out of ``DAG_RUN_PENDING`` at all, so a run containing one simply never
+        reaches a pending count of zero and this method is never invoked for it. Since
+        only ``COMPLETED`` tasks ever reach here, reaching a pending count of zero means
+        every task the run has ever registered completed successfully -- so this also
+        marks the run's aggregate status ``complete`` (via ``mark_dag_run_complete``,
+        itself gated on the run having never recorded a failed task, defensively).
         """
         assert task.dag_run_id is not None  # noqa: S101
         remaining = await self.close_dag_run_task(task.dag_run_id, task.id)
@@ -1026,6 +1055,7 @@ class StateManager:
             # -1: already closed (duplicate call) or the run's pending entry expired/was
             # swept — either way, do not re-trigger the sweep from here.
             return
+        await self.mark_dag_run_complete(task.dag_run_id)
         await self.sweep_dag_run(task.dag_run_id, fallback_task=task)
 
     async def delete_task(self, task: Task) -> None:

--- a/jobbers/task_processor.py
+++ b/jobbers/task_processor.py
@@ -267,45 +267,17 @@ class TaskProcessor:
         """
         Delete the task record if its final status is in cleanup_on.
 
-        For standalone tasks this is a direct check. For DAG tasks, an atomic
-        per-run pending counter (rather than re-fetching every sibling on each
-        completion) detects when the whole run has gone terminal; the full
-        sibling sweep then runs exactly once, when the counter reaches zero,
-        instead of being redone from scratch on every one of the run's completions.
-
-        A DAG task in a stuck status (``TaskStatus.stuck_statuses()`` — FAILED,
-        STALLED, CANCELLED, or DROPPED) never closes out of the pending counter at
-        all: such a task never calls ``generate_callbacks()``, so its
-        ``FanInCallback``/``DynamicFanOutCallback`` never fires and the DAG can't
-        complete on its own. Leaving the counter open preserves the run's fan-in
-        tracking and sibling task records (within their TTLs) instead of sweeping
-        them away — a foundation for a future DAG-resume mechanism.
-
-        Independent of all of the above, ``record_dag_run_task_terminal`` is called
-        for *every* terminal DAG task (stuck or not) to update the run's aggregate
-        completed/failed status counters — this is wholly additive and never gated
-        on ``cleanup_on``/pending state the way the sweep above is.
-
-        ``record_dag_run_task_terminal`` must run *before* ``close_dag_run_task_and_
-        sweep``, not after: its recompute step unconditionally rewrites the run's
-        status field (to 'running'/'partial_failure'/'failed', never 'complete'), so
-        if it ran after close_dag_run_task_and_sweep's mark_dag_run_complete on the
-        run's last task, it would immediately clobber the 'complete' write back to
-        'running'. Calling it first means mark_dag_run_complete's write is always the
-        last one for that task, and — because within one task's call here record
-        strictly precedes close, and pending only reaches zero once every task's own
-        close has run — every sibling's record call is guaranteed to have already
-        posted by the time the run's pending count reaches zero, regardless of how
-        concurrent completions interleave.
+        For standalone tasks this is a direct check. For DAG tasks, delegates
+        entirely to ``StateManager.finalize_dag_run_task``, which owns both the
+        aggregate-status bookkeeping and the pending-counter/sweep logic (and the
+        ordering constraint between them — see its docstring). TaskProcessor just
+        needs to call it exactly once per DAG-task completion, regardless of
+        whether the task's terminal status is stuck or not.
         """
         if task.dag_run_id is None:
             await self._maybe_delete_self(task)
             return
-        if task.status in TaskStatus.stuck_statuses():
-            await self.state_manager.record_dag_run_task_terminal(task)
-            return
-        await self.state_manager.record_dag_run_task_terminal(task)
-        await self.state_manager.close_dag_run_task_and_sweep(task)
+        await self.state_manager.finalize_dag_run_task(task)
 
     async def _maybe_delete_self(self, task: Task) -> None:
         """Delete a standalone (non-DAG) task's record if its status matches cleanup_on."""

--- a/jobbers/task_processor.py
+++ b/jobbers/task_processor.py
@@ -273,19 +273,38 @@ class TaskProcessor:
         sibling sweep then runs exactly once, when the counter reaches zero,
         instead of being redone from scratch on every one of the run's completions.
 
-        A DAG task in a stuck status (``TaskStatus.stuck_statuses()`` — FAILED or
-        STALLED) never closes out of the pending counter at all: such a task never
-        calls ``generate_callbacks()``, so its ``FanInCallback``/
-        ``DynamicFanOutCallback`` never fires and the DAG can't complete on its
-        own. Leaving the counter open preserves the run's fan-in tracking and
-        sibling task records (within their TTLs) instead of sweeping them away —
-        a foundation for a future DAG-resume mechanism.
+        A DAG task in a stuck status (``TaskStatus.stuck_statuses()`` — FAILED,
+        STALLED, CANCELLED, or DROPPED) never closes out of the pending counter at
+        all: such a task never calls ``generate_callbacks()``, so its
+        ``FanInCallback``/``DynamicFanOutCallback`` never fires and the DAG can't
+        complete on its own. Leaving the counter open preserves the run's fan-in
+        tracking and sibling task records (within their TTLs) instead of sweeping
+        them away — a foundation for a future DAG-resume mechanism.
+
+        Independent of all of the above, ``record_dag_run_task_terminal`` is called
+        for *every* terminal DAG task (stuck or not) to update the run's aggregate
+        completed/failed status counters — this is wholly additive and never gated
+        on ``cleanup_on``/pending state the way the sweep above is.
+
+        ``record_dag_run_task_terminal`` must run *before* ``close_dag_run_task_and_
+        sweep``, not after: its recompute step unconditionally rewrites the run's
+        status field (to 'running'/'partial_failure'/'failed', never 'complete'), so
+        if it ran after close_dag_run_task_and_sweep's mark_dag_run_complete on the
+        run's last task, it would immediately clobber the 'complete' write back to
+        'running'. Calling it first means mark_dag_run_complete's write is always the
+        last one for that task, and — because within one task's call here record
+        strictly precedes close, and pending only reaches zero once every task's own
+        close has run — every sibling's record call is guaranteed to have already
+        posted by the time the run's pending count reaches zero, regardless of how
+        concurrent completions interleave.
         """
         if task.dag_run_id is None:
             await self._maybe_delete_self(task)
             return
         if task.status in TaskStatus.stuck_statuses():
+            await self.state_manager.record_dag_run_task_terminal(task)
             return
+        await self.state_manager.record_dag_run_task_terminal(task)
         await self.state_manager.close_dag_run_task_and_sweep(task)
 
     async def _maybe_delete_self(self, task: Task) -> None:
@@ -468,14 +487,17 @@ class TaskProcessor:
         Rate limits on arm queues are bypassed with a warning logged.
         """
         # Fan-in tracking is scoped per DAG run. A task fanning out without already
-        # being part of one starts a fresh run for the fanned-out sub-graph.
+        # being part of one starts a fresh run for the fanned-out sub-graph, with no
+        # user-supplied name available to inherit -- default to a name derived from
+        # the dispatching task.
         dag_run_id = parent.dag_run_id or ULID()
+        dag_run_name = parent.dag_run_name or f"{parent.name} (fan-out)"
 
         if not fanout.arms:
             # Degenerate case: no arms — submit the collector immediately. Outer fan-in
             # callbacks still need to be delegated to it, exactly as in the normal path
             # below, otherwise an outer fan-in waiting on *parent* never gets closed.
-            solo = fanout.collector.to_task(dag_run_id=dag_run_id)
+            solo = fanout.collector.to_task(dag_run_id=dag_run_id, dag_run_name=dag_run_name)
             await self._delegate_outer_fan_in(
                 solo, dag_run_id, parent.id, fanout.collector.id, outer_fan_in_cbs
             )
@@ -510,8 +532,11 @@ class TaskProcessor:
         all_fan_ins[fan_in_key] = terminal_ids
 
         # 4. Build tasks: submit arm roots, collector waits for terminal IDs.
-        arm_tasks = [arm.to_task(parent_id=parent.id, dag_run_id=dag_run_id) for arm in fanout.arms]
-        collector_task = fanout.collector.to_task(dag_run_id=dag_run_id)
+        arm_tasks = [
+            arm.to_task(parent_id=parent.id, dag_run_id=dag_run_id, dag_run_name=dag_run_name)
+            for arm in fanout.arms
+        ]
+        collector_task = fanout.collector.to_task(dag_run_id=dag_run_id, dag_run_name=dag_run_name)
         collector_task.parent_ids = list(terminal_ids)
 
         # 5. Delegation: transfer outer fan-in callbacks to the collector and

--- a/jobbers/task_routes.py
+++ b/jobbers/task_routes.py
@@ -530,6 +530,10 @@ class SubmitDAGRequest(BaseModel):
     """Request body for ad-hoc DAG submission from a mermaid diagram."""
 
     diagram: str = Field(description="Mermaid flowchart text describing the DAG.")
+    name: str | None = Field(
+        default=None,
+        description="Human-readable name for this DAG run. Defaults to the generated dag_run_id if omitted.",
+    )
 
 
 @app.post("/submit-dag")
@@ -548,9 +552,14 @@ async def submit_dag(request: SubmitDAGRequest) -> dict[str, Any]:
 
     _validate_dag_against_registry(roots)
 
+    # Generated here (rather than left to StateManager.submit_dag's internal default)
+    # so an omitted name can default to this exact ID.
+    dag_run_id = ULID()
+    name = request.name or str(dag_run_id)
+
     sm = db.get_state_manager()
     try:
-        dag_run_id, submitted = await sm.submit_dag(*roots)
+        dag_run_id, submitted = await sm.submit_dag(*roots, name=name, dag_run_id=dag_run_id)
     except TaskRateLimitedError as exc:
         raise HTTPException(status_code=429, detail=str(exc)) from exc
     return {"dag_run_id": str(dag_run_id), "root_task_ids": [str(t.id) for t in submitted]}
@@ -695,7 +704,15 @@ async def list_dags(pagination: Annotated[DAGRunPagination, Query()]) -> dict[st
     dag_runs, total = await sm.list_dag_runs(pagination)
     return {
         "total": total,
-        "dags": [{"dag_run_id": str(rid), "submitted_at": ts.isoformat()} for rid, ts in dag_runs],
+        "dags": [
+            {
+                "dag_run_id": str(run.dag_run_id),
+                "name": run.name,
+                "status": run.status.value,
+                "submitted_at": run.submitted_at.isoformat(),
+            }
+            for run in dag_runs
+        ],
     }
 
 
@@ -707,9 +724,10 @@ async def get_dag(dag_run_id: str) -> dict[str, Any]:
     result = await sm.get_dag_run(uid)
     if result is None:
         raise HTTPException(status_code=404, detail=f"DAG run '{dag_run_id}' not found.")
-    submitted_at, task_ids = result
     return {
-        "dag_run_id": dag_run_id,
-        "submitted_at": submitted_at.isoformat(),
-        "task_ids": [str(t) for t in task_ids],
+        "dag_run_id": str(result.dag_run_id),
+        "name": result.name,
+        "status": result.status.value,
+        "submitted_at": result.submitted_at.isoformat(),
+        "task_ids": [str(t) for t in result.task_ids],
     }

--- a/openapi.json
+++ b/openapi.json
@@ -279,11 +279,11 @@
                   "type": "string",
                   "minLength": 26,
                   "maxLength": 26,
-                  "pattern": "[A-Z0-9]{26}"
+                  "pattern": "[0-7][0123456789ABCDEFGHJKMNPQRSTVWXYZ]{25}"
                 },
                 {
                   "type": "string",
-                  "format": "binary",
+                  "contentMediaType": "application/octet-stream",
                   "minLength": 16,
                   "maxLength": 16
                 },
@@ -988,11 +988,11 @@
                   "type": "string",
                   "minLength": 26,
                   "maxLength": 26,
-                  "pattern": "[A-Z0-9]{26}"
+                  "pattern": "[0-7][0123456789ABCDEFGHJKMNPQRSTVWXYZ]{25}"
                 },
                 {
                   "type": "string",
-                  "format": "binary",
+                  "contentMediaType": "application/octet-stream",
                   "minLength": 16,
                   "maxLength": 16
                 },
@@ -1266,6 +1266,48 @@
                   "type": "object",
                   "additionalProperties": true,
                   "title": "Response Delete Role Roles  Role Name  Delete"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/roles/{role_name}/refresh": {
+      "post": {
+        "summary": "Refresh Role",
+        "description": "Bump the refresh tag for a role, causing workers to reload their queue list on the next poll.",
+        "operationId": "refresh_role_roles__role_name__refresh_post",
+        "parameters": [
+          {
+            "name": "role_name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Role Name"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Refresh Role Roles  Role Name  Refresh Post"
                 }
               }
             }
@@ -1892,13 +1934,13 @@
                 "type": "string",
                 "maxLength": 26,
                 "minLength": 26,
-                "pattern": "[A-Z0-9]{26}"
+                "pattern": "[0-7][0123456789ABCDEFGHJKMNPQRSTVWXYZ]{25}"
               },
               {
                 "type": "string",
                 "maxLength": 16,
                 "minLength": 16,
-                "format": "binary"
+                "contentMediaType": "application/octet-stream"
               }
             ],
             "title": "Id"
@@ -1931,11 +1973,15 @@
                 },
                 {
                   "$ref": "#/components/schemas/FanInCallback"
+                },
+                {
+                  "$ref": "#/components/schemas/DynamicFanOutCallback"
                 }
               ],
               "discriminator": {
                 "propertyName": "type",
                 "mapping": {
+                  "dynamic_fanout": "#/components/schemas/DynamicFanOutCallback",
                   "fan_in": "#/components/schemas/FanInCallback",
                   "simple": "#/components/schemas/SimpleCallback"
                 }
@@ -2052,6 +2098,54 @@
         "title": "DeadLetterPolicy",
         "description": "Dead letter policy to use when a task fails."
       },
+      "DynamicFanOutCallback": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "dynamic_fanout",
+            "title": "Type",
+            "default": "dynamic_fanout"
+          },
+          "arm_root": {
+            "$ref": "#/components/schemas/DAGTaskSpec"
+          },
+          "collector": {
+            "$ref": "#/components/schemas/DAGTaskSpec"
+          },
+          "items_key": {
+            "type": "string",
+            "title": "Items Key",
+            "default": "items"
+          },
+          "fan_in_ttl": {
+            "type": "integer",
+            "title": "Fan In Ttl",
+            "default": 86400
+          },
+          "propagate_fan_in": {
+            "type": "boolean",
+            "title": "Propagate Fan In",
+            "default": true
+          },
+          "error_callback": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/DAGTaskSpec"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "type": "object",
+        "required": [
+          "arm_root",
+          "collector"
+        ],
+        "title": "DynamicFanOutCallback",
+        "description": "Declarative dynamic fan-out driven by the dispatcher task's result data.\n\nThe processor reads arm parameters from the dispatcher task's results and\nspawns one arm instance per entry.\n\n``arm_root`` is a template ``DAGTaskSpec`` for the root of each arm chain.\nEach entry in ``dispatcher.results[items_key]`` (a list of dicts) is\nshallow-merged into the arm root's parameters (entry values take precedence\nover the template's static parameters).\n\n``collector`` is submitted once all arm terminals have completed (fan-in).\n\n``propagate_fan_in`` mirrors the same field on ``DynamicFanOut``: when\n``True`` (the default), if this dispatcher is itself an arm of an outer\nfan-in, the outer fan-in responsibility is transferred to ``collector``\nso the outer fan-in waits for the collector rather than the dispatcher.\n\nThis callback type is produced by the mermaid parser when it encounters a\n``-->>`` fan-out edge.  Task functions that need runtime control over arm\nstructure should continue to use ``DynamicFanOut`` / ``TaskResult`` instead."
+      },
       "FanInCallback": {
         "properties": {
           "type": {
@@ -2089,7 +2183,7 @@
           "fan_in_key"
         ],
         "title": "FanInCallback",
-        "description": "Submit `task` only once all fan-in predecessors have completed.\n\n`fan_in_key` is a Redis key for a set of pending predecessor task IDs.\nEach predecessor removes its own ID via `TaskAdapterProtocol.fan_in_complete`;\nwhen the set becomes empty the collector task is submitted."
+        "description": "Submit `task` only once all fan-in predecessors have completed.\n\n`fan_in_key` is a Redis key for a set of pending predecessor task IDs.\nEach predecessor removes its own ID via `TaskStateProtocol.fan_in_complete`;\nwhen the set becomes empty the collector task is submitted."
       },
       "HTTPValidationError": {
         "properties": {
@@ -2122,7 +2216,8 @@
           "max_concurrent": {
             "anyOf": [
               {
-                "type": "integer"
+                "type": "integer",
+                "minimum": 0.0
               },
               {
                 "type": "null"
@@ -2354,6 +2449,18 @@
             "type": "string",
             "title": "Diagram",
             "description": "Mermaid flowchart text describing the DAG."
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name",
+            "description": "Human-readable name for this DAG run. Defaults to the generated dag_run_id if omitted."
           }
         },
         "type": "object",
@@ -2371,13 +2478,13 @@
                 "type": "string",
                 "maxLength": 26,
                 "minLength": 26,
-                "pattern": "[A-Z0-9]{26}"
+                "pattern": "[0-7][0123456789ABCDEFGHJKMNPQRSTVWXYZ]{25}"
               },
               {
                 "type": "string",
                 "maxLength": 16,
                 "minLength": 16,
-                "format": "binary"
+                "contentMediaType": "application/octet-stream"
               }
             ],
             "title": "Id"
@@ -2503,11 +2610,15 @@
                 },
                 {
                   "$ref": "#/components/schemas/FanInCallback"
+                },
+                {
+                  "$ref": "#/components/schemas/DynamicFanOutCallback"
                 }
               ],
               "discriminator": {
                 "propertyName": "type",
                 "mapping": {
+                  "dynamic_fanout": "#/components/schemas/DynamicFanOutCallback",
                   "fan_in": "#/components/schemas/FanInCallback",
                   "simple": "#/components/schemas/SimpleCallback"
                 }
@@ -2523,13 +2634,13 @@
                   "type": "string",
                   "maxLength": 26,
                   "minLength": 26,
-                  "pattern": "[A-Z0-9]{26}"
+                  "pattern": "[0-7][0123456789ABCDEFGHJKMNPQRSTVWXYZ]{25}"
                 },
                 {
                   "type": "string",
                   "maxLength": 16,
                   "minLength": 16,
-                  "format": "binary"
+                  "contentMediaType": "application/octet-stream"
                 }
               ]
             },
@@ -2547,13 +2658,13 @@
                 "type": "string",
                 "maxLength": 26,
                 "minLength": 26,
-                "pattern": "[A-Z0-9]{26}"
+                "pattern": "[0-7][0123456789ABCDEFGHJKMNPQRSTVWXYZ]{25}"
               },
               {
                 "type": "string",
                 "maxLength": 16,
                 "minLength": 16,
-                "format": "binary"
+                "contentMediaType": "application/octet-stream"
               },
               {
                 "type": "null"
@@ -2567,19 +2678,30 @@
                 "type": "string",
                 "maxLength": 26,
                 "minLength": 26,
-                "pattern": "[A-Z0-9]{26}"
+                "pattern": "[0-7][0123456789ABCDEFGHJKMNPQRSTVWXYZ]{25}"
               },
               {
                 "type": "string",
                 "maxLength": 16,
                 "minLength": 16,
-                "format": "binary"
+                "contentMediaType": "application/octet-stream"
               },
               {
                 "type": "null"
               }
             ],
             "title": "Dag Run Id"
+          },
+          "dag_run_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Dag Run Name"
           }
         },
         "type": "object",
@@ -2657,6 +2779,21 @@
             "$ref": "#/components/schemas/DeadLetterPolicy",
             "default": "none"
           },
+          "cleanup_on": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/TaskStatus"
+                },
+                "type": "array",
+                "uniqueItems": true
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cleanup On"
+          },
           "max_heartbeat_interval": {
             "anyOf": [
               {
@@ -2677,18 +2814,19 @@
           "expected_exceptions": {
             "anyOf": [
               {
-                "prefixItems": [
-                  {}
-                ],
-                "type": "array",
-                "maxItems": 1,
-                "minItems": 1
+                "items": {},
+                "type": "array"
               },
               {
                 "type": "null"
               }
             ],
             "title": "Expected Exceptions"
+          },
+          "dependency_graph": {
+            "type": "array",
+            "title": "Dependency Graph",
+            "readOnly": true
           }
         },
         "type": "object",
@@ -2748,6 +2886,13 @@
           "type": {
             "type": "string",
             "title": "Error Type"
+          },
+          "input": {
+            "title": "Input"
+          },
+          "ctx": {
+            "type": "object",
+            "title": "Context"
           }
         },
         "type": "object",

--- a/tests/adapters/test_redis_task_state.py
+++ b/tests/adapters/test_redis_task_state.py
@@ -507,12 +507,18 @@ async def test_stage_register_dag_run_adds_to_dag_runs_set(redis_task_adapter):
     dag_run_id = ULID()
     task = make_task()
     task.dag_run_id = dag_run_id
+    task.dag_run_name = "my-run"
     pipe = state.data_store.pipeline(transaction=True)
     state.stage_submit_task(pipe, task)
     await pipe.execute()
     score = await state.data_store.zscore(state.DAG_RUNS, bytes(dag_run_id))
     assert score is not None
     assert score == pytest.approx(FROZEN_TIME.timestamp())
+
+    detail = await state.get_dag_run(dag_run_id)
+    assert detail is not None
+    assert detail.name == "my-run"
+    assert detail.status.value == "running"
 
 
 @pytest.mark.asyncio

--- a/tests/adapters/test_task_state_common.py
+++ b/tests/adapters/test_task_state_common.py
@@ -17,7 +17,7 @@ from ulid import ULID
 
 from jobbers.adapters.redis import RedisTaskState
 from jobbers.adapters.redis_json import RedisJSONTaskState
-from jobbers.models.dag import DAGRunPagination
+from jobbers.models.dag import DAGRunPagination, DagRunStatus
 from jobbers.models.task import PaginationOrder, Task, TaskPagination
 from jobbers.models.task_status import TaskStatus
 
@@ -790,9 +790,9 @@ async def test_get_dag_runs_returns_submitted_dag_runs(task_adapter):
     await submit.submit_task(task)
     runs, total = await state.get_dag_runs(DAGRunPagination())
     assert total == 1
-    run_id, submitted_at = runs[0]
-    assert run_id == ULID1
-    assert submitted_at == pytest.approx(FROZEN_TIME, abs=dt.timedelta(seconds=1))
+    run = runs[0]
+    assert run.dag_run_id == ULID1
+    assert run.submitted_at == pytest.approx(FROZEN_TIME, abs=dt.timedelta(seconds=1))
 
 
 @pytest.mark.asyncio
@@ -815,9 +815,8 @@ async def test_get_dag_run_returns_submitted_at_and_task_ids(task_adapter):
     await submit.submit_task(task_b)
     result = await state.get_dag_run(dag_run_id)
     assert result is not None
-    submitted_at, task_ids = result
-    assert submitted_at == pytest.approx(FROZEN_TIME, abs=dt.timedelta(seconds=1))
-    assert set(task_ids) == {ULID2, ULID3}
+    assert result.submitted_at == pytest.approx(FROZEN_TIME, abs=dt.timedelta(seconds=1))
+    assert set(result.task_ids) == {ULID2, ULID3}
 
 
 @pytest.mark.asyncio
@@ -847,8 +846,7 @@ async def test_get_dag_run_task_ids_are_chronologically_ordered(task_adapter):
 
     result = await state.get_dag_run(dag_run_id)
     assert result is not None
-    _, task_ids = result
-    assert task_ids == [earliest, middle, latest]
+    assert result.task_ids == [earliest, middle, latest]
 
 
 # ── clean_dag_runs ────────────────────────────────────────────────────────────
@@ -877,7 +875,7 @@ async def test_clean_dag_runs_keeps_recent_entries(task_adapter):
     await state.clean_dag_runs(FROZEN_TIME, dt.timedelta(days=7))
     runs, total = await state.get_dag_runs(DAGRunPagination())
     assert total == 1
-    assert runs[0][0] == ULID1
+    assert runs[0].dag_run_id == ULID1
 
 
 # ── close_dag_run_task ────────────────────────────────────────────────────────
@@ -922,6 +920,91 @@ async def test_close_dag_run_task_returns_minus_one_for_unregistered_task(task_a
     await submit.submit_task(task)
 
     assert await state.close_dag_run_task(dag_run_id, ULID3) == -1
+
+
+# ── DAG run aggregate status ────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_get_dag_runs_includes_name_and_default_running_status(task_adapter):
+    """A freshly registered run appears with its name and status='running'."""
+    state, submit = task_adapter
+    task = make_task(submitted_at=FROZEN_TIME)
+    task.dag_run_id = ULID1
+    task.dag_run_name = "my-run"
+    await submit.submit_task(task)
+
+    runs, _ = await state.get_dag_runs(DAGRunPagination())
+    assert runs[0].name == "my-run"
+    assert runs[0].status == DagRunStatus.RUNNING
+
+    detail = await state.get_dag_run(ULID1)
+    assert detail is not None
+    assert detail.name == "my-run"
+    assert detail.status == DagRunStatus.RUNNING
+
+
+@pytest.mark.asyncio
+async def test_record_dag_run_task_terminal_failed_only_yields_failed(task_adapter):
+    """A run with only failed outcomes (zero completions) has status='failed'."""
+    state, submit = task_adapter
+    task = make_task(submitted_at=FROZEN_TIME)
+    task.dag_run_id = ULID1
+    await submit.submit_task(task)
+
+    await state.record_dag_run_task_terminal(ULID1, "failed")
+
+    detail = await state.get_dag_run(ULID1)
+    assert detail is not None
+    assert detail.status == DagRunStatus.FAILED
+
+
+@pytest.mark.asyncio
+async def test_record_dag_run_task_terminal_failed_then_completed_yields_partial_failure(task_adapter):
+    """A run with a mix of failed and completed outcomes has status='partial_failure'."""
+    state, submit = task_adapter
+    task = make_task(submitted_at=FROZEN_TIME)
+    task.dag_run_id = ULID1
+    await submit.submit_task(task)
+
+    await state.record_dag_run_task_terminal(ULID1, "failed")
+    await state.record_dag_run_task_terminal(ULID1, "completed")
+
+    detail = await state.get_dag_run(ULID1)
+    assert detail is not None
+    assert detail.status == DagRunStatus.PARTIAL_FAILURE
+
+
+@pytest.mark.asyncio
+async def test_mark_dag_run_complete_sets_complete_when_failed_count_zero(task_adapter):
+    """mark_dag_run_complete sets status='complete' when the run has never recorded a failure."""
+    state, submit = task_adapter
+    task = make_task(submitted_at=FROZEN_TIME)
+    task.dag_run_id = ULID1
+    await submit.submit_task(task)
+
+    await state.record_dag_run_task_terminal(ULID1, "completed")
+    await state.mark_dag_run_complete(ULID1)
+
+    detail = await state.get_dag_run(ULID1)
+    assert detail is not None
+    assert detail.status == DagRunStatus.COMPLETE
+
+
+@pytest.mark.asyncio
+async def test_mark_dag_run_complete_noop_when_failed_count_nonzero(task_adapter):
+    """mark_dag_run_complete does not overwrite a failed/partial_failure status."""
+    state, submit = task_adapter
+    task = make_task(submitted_at=FROZEN_TIME)
+    task.dag_run_id = ULID1
+    await submit.submit_task(task)
+
+    await state.record_dag_run_task_terminal(ULID1, "failed")
+    await state.mark_dag_run_complete(ULID1)
+
+    detail = await state.get_dag_run(ULID1)
+    assert detail is not None
+    assert detail.status == DagRunStatus.FAILED
 
 
 # ── fan-in ────────────────────────────────────────────────────────────────────

--- a/tests/adapters/test_task_submit_common.py
+++ b/tests/adapters/test_task_submit_common.py
@@ -128,8 +128,7 @@ async def test_enqueue_registers_dag_run(task_adapter):
 
     run = await state.get_dag_run(dag_run_id)
     assert run is not None
-    _, task_ids = run
-    assert ULID1 in task_ids
+    assert ULID1 in run.task_ids
 
 
 # ── get_next_task ─────────────────────────────────────────────────────────────

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -139,6 +139,12 @@ class DummyTaskState:
     async def close_dag_run_task(self, dag_run_id: ULID, task_id: ULID) -> int:
         raise NotImplementedError("DummyTaskState.close_dag_run_task")
 
+    async def record_dag_run_task_terminal(self, dag_run_id: ULID, outcome: object) -> None:
+        raise NotImplementedError("DummyTaskState.record_dag_run_task_terminal")
+
+    async def mark_dag_run_complete(self, dag_run_id: ULID) -> None:
+        raise NotImplementedError("DummyTaskState.mark_dag_run_complete")
+
     async def ensure_index(self) -> None:
         raise NotImplementedError("DummyTaskState.ensure_index")
 

--- a/tests/test_end2end.py
+++ b/tests/test_end2end.py
@@ -17,6 +17,7 @@ from jobbers.adapters.redis import (
     RedisTaskSubmit,
 )
 from jobbers.adapters.sql import SQLQueueConfigAdapter, SQLRoutingBackend
+from jobbers.models.dag import DagRunStatus
 from jobbers.models.queue_config import QueueConfig
 from jobbers.models.task_status import TaskStatus
 from jobbers.registry import clear_registry
@@ -76,6 +77,17 @@ async def drain(sm: StateManager) -> int:
     return count
 
 
+async def pop_and_process_one(sm: StateManager, queue: str = "default") -> None:
+    """Pop and process exactly one task from *queue* (no draining loop)."""
+    ta = sm.task_state
+    results = await ta.data_store.zpopmin(ta.TASKS_BY_QUEUE(queue=queue), count=1)
+    assert results, f"expected a queued task in {queue!r}"
+    task_id_bytes, _ = results[0]
+    task = await ta.get_task(ULID.from_bytes(task_id_bytes))
+    assert task is not None
+    await TaskProcessor(sm).run(task)
+
+
 async def tick_scheduler(sm: StateManager) -> int:
     """Dispatch all currently-due scheduled tasks. Returns count dispatched."""
     entries = await sm.task_scheduler.next_due_bulk(100)
@@ -104,7 +116,7 @@ async def test_single_node_happy_path(sm: StateManager) -> None:
       A["echo_task@1(value=a)"]
     """
     roots = parse_mermaid_dag(diagram)
-    _, submitted = await sm.submit_dag(*roots)
+    _, submitted = await sm.submit_dag(*roots, name="test-run")
     await run_until_done(sm)
 
     assert len(submitted) == 1
@@ -129,7 +141,7 @@ async def test_linear_chain(sm: StateManager) -> None:
       A["echo_task@1(value=a)"] --> B["echo_task@1(value=b)"] --> C["echo_task@1(value=c)"]
     """
     roots = parse_mermaid_dag(diagram)
-    await sm.submit_dag(*roots)
+    await sm.submit_dag(*roots, name="test-run")
     await run_until_done(sm)
 
     a_node = roots[0]
@@ -170,7 +182,7 @@ async def test_diamond_fan_out_fan_in(sm: StateManager) -> None:
       C["echo_task@1(value=c)"] --> D["echo_task@1(value=d)"]
     """
     roots = parse_mermaid_dag(diagram)
-    await sm.submit_dag(*roots)
+    await sm.submit_dag(*roots, name="test-run")
     await run_until_done(sm)
 
     a_node = roots[0]
@@ -215,7 +227,7 @@ async def test_error_callback_fires_on_failure(sm: StateManager) -> None:
       A -.-> C["echo_task@1(value=error_cb)"]
     """
     roots = parse_mermaid_dag(diagram)
-    await sm.submit_dag(*roots)
+    await sm.submit_dag(*roots, name="test-run")
     await run_until_done(sm)
 
     a_node = roots[0]
@@ -249,7 +261,7 @@ async def test_downstream_not_submitted_on_parent_failure(sm: StateManager) -> N
       A["always_fail_task@1"] --> B["echo_task@1(value=b)"]
     """
     roots = parse_mermaid_dag(diagram)
-    await sm.submit_dag(*roots)
+    await sm.submit_dag(*roots, name="test-run")
     await run_until_done(sm)
 
     a_node = roots[0]
@@ -275,7 +287,7 @@ async def test_multi_root_dag(sm: StateManager) -> None:
       B["echo_task@1(value=b)"]
     """
     roots = parse_mermaid_dag(diagram)
-    await sm.submit_dag(*roots)
+    await sm.submit_dag(*roots, name="test-run")
     await run_until_done(sm)
 
     # roots order is non-deterministic (set iteration); look up by parameter
@@ -304,7 +316,7 @@ async def test_retry_exhaustion_dlq(sm: StateManager) -> None:
       A["always_fail_task@1"]
     """
     roots = parse_mermaid_dag(diagram)
-    _, submitted = await sm.submit_dag(*roots)
+    _, submitted = await sm.submit_dag(*roots, name="test-run")
     await run_until_done(sm)
 
     task = await sm.task_state.get_task(submitted[0].id)
@@ -328,7 +340,7 @@ async def test_scheduled_retry_path(sm: StateManager) -> None:
       A["scheduled_fail_task@1"]
     """
     roots = parse_mermaid_dag(diagram)
-    _, submitted = await sm.submit_dag(*roots)
+    _, submitted = await sm.submit_dag(*roots, name="test-run")
     task_id = submitted[0].id
 
     await run_until_done(sm)
@@ -354,7 +366,7 @@ async def test_parameters_passed_and_results(sm: StateManager) -> None:
       A["echo_task@1(value=hello)"]
     """
     roots = parse_mermaid_dag(diagram)
-    _, submitted = await sm.submit_dag(*roots)
+    _, submitted = await sm.submit_dag(*roots, name="test-run")
     await run_until_done(sm)
 
     task = await sm.task_state.get_task(submitted[0].id)
@@ -386,7 +398,7 @@ async def test_cancel_running_task(sm: StateManager) -> None:
       A["slow_task@1"]
     """
     roots = parse_mermaid_dag(diagram)
-    _, submitted = await sm.submit_dag(*roots)
+    _, submitted = await sm.submit_dag(*roots, name="test-run")
     task_id = submitted[0].id
 
     cancel_listener = asyncio.create_task(sm.run_cancel_listener())
@@ -414,7 +426,7 @@ async def test_cancel_dag_root_leaves_downstream_unsubmitted(sm: StateManager) -
       A["slow_task@1"] --> B["echo_task@1(value=b)"]
     """
     roots = parse_mermaid_dag(diagram)
-    await sm.submit_dag(*roots)
+    await sm.submit_dag(*roots, name="test-run")
 
     a_node = roots[0]
     b_node = a_node._successors[0][0]
@@ -437,3 +449,92 @@ async def test_cancel_dag_root_leaves_downstream_unsubmitted(sm: StateManager) -
     assert task_a is not None
     assert task_a.status == TaskStatus.CANCELLED
     assert task_b is None  # successor was never submitted
+
+
+# ── Scenario 11: DAG run aggregate status ──────────────────────────────────────
+#
+# These exercise the real RedisTaskState/RedisTaskSubmit adapters (via the `sm`
+# fixture, not DummyTaskAdapter) end-to-end through TaskProcessor.run(), since the
+# ordering/atomicity of the aggregate-status write path is exactly the kind of
+# interaction Dummy-backed orchestration tests can't prove is race-free.
+
+
+@pytest.mark.asyncio
+async def test_dag_run_reaches_complete_status_only_after_last_task(sm: StateManager) -> None:
+    """A 2-root DAG's aggregate status becomes 'complete' only once every task has completed."""
+    diagram = """
+    flowchart TD
+      A["echo_task@1(value=a)"]
+      B["echo_task@1(value=b)"]
+    """
+    roots = parse_mermaid_dag(diagram)
+    dag_run_id, submitted = await sm.submit_dag(*roots, name="two-root-run")
+    assert len(submitted) == 2
+
+    await pop_and_process_one(sm)
+
+    run = await sm.get_dag_run(dag_run_id)
+    assert run is not None
+    assert run.name == "two-root-run"
+    assert run.status == DagRunStatus.RUNNING  # one task done, one still pending
+
+    await pop_and_process_one(sm)
+
+    run = await sm.get_dag_run(dag_run_id)
+    assert run is not None
+    assert run.status == DagRunStatus.COMPLETE
+
+
+@pytest.mark.asyncio
+async def test_dag_run_with_one_stuck_task_latches_to_partial_failure_and_never_completes(
+    sm: StateManager,
+) -> None:
+    """A run with a mix of a completed and a permanently-failed task reaches 'partial_failure' and stays there."""
+    diagram = """
+    flowchart TD
+      A["echo_task@1(value=a)"]
+      B["always_fail_task@1"]
+    """
+    roots = parse_mermaid_dag(diagram)
+    dag_run_id, submitted = await sm.submit_dag(*roots, name="mixed-run")
+    assert len(submitted) == 2
+
+    await run_until_done(sm)
+
+    run = await sm.get_dag_run(dag_run_id)
+    assert run is not None
+    assert run.status == DagRunStatus.PARTIAL_FAILURE
+
+    # The stuck (FAILED) task never lets the pending count reach zero, so the
+    # complete-detection path (close_dag_run_task_and_sweep) never fires for this
+    # run -- status must stay latched at partial_failure, never flip to complete.
+    b_task = await sm.task_state.get_task(
+        submitted[1].id if submitted[0].name == "echo_task" else submitted[0].id
+    )
+    assert b_task is not None
+    assert b_task.status == TaskStatus.FAILED
+
+
+@pytest.mark.asyncio
+async def test_dag_run_concurrent_last_completers_both_reach_complete_idempotently(sm: StateManager) -> None:
+    """Two siblings finishing concurrently and both hitting the 'last completer' path is race-free."""
+    diagram = """
+    flowchart TD
+      A["echo_task@1(value=a)"]
+      B["echo_task@1(value=b)"]
+    """
+    roots = parse_mermaid_dag(diagram)
+    dag_run_id, submitted = await sm.submit_dag(*roots, name="concurrent-run")
+    assert len(submitted) == 2
+
+    ta = sm.task_state
+    results = await ta.data_store.zpopmin(ta.TASKS_BY_QUEUE(queue="default"), count=2)
+    assert len(results) == 2
+    tasks = [await ta.get_task(ULID.from_bytes(task_id_bytes)) for task_id_bytes, _ in results]
+    assert all(t is not None for t in tasks)
+
+    await asyncio.gather(*(TaskProcessor(sm).run(t) for t in tasks))
+
+    run = await sm.get_dag_run(dag_run_id)
+    assert run is not None
+    assert run.status == DagRunStatus.COMPLETE

--- a/tests/test_state_manager.py
+++ b/tests/test_state_manager.py
@@ -1105,13 +1105,36 @@ async def test_submit_dag_simple_chain(state_manager):
     child = DAGNode("process_data")
     root.then(child)
 
-    dag_run_id, submitted = await state_manager.submit_dag(root)
+    dag_run_id, submitted = await state_manager.submit_dag(root, name="my-run")
 
     assert dag_run_id is not None
     assert len(submitted) == 1
     assert submitted[0].id == root.id
     assert submitted[0].status == TaskStatus.SUBMITTED
     assert submitted[0].dag_run_id is not None
+    assert submitted[0].dag_run_name == "my-run"
+
+
+@pytest.mark.asyncio
+async def test_submit_dag_defaults_dag_run_id_when_no_name_and_no_override(state_manager):
+    """submit_dag self-generates a dag_run_id when neither name nor dag_run_id is supplied."""
+    root = DAGNode("fetch_data")
+
+    dag_run_id, submitted = await state_manager.submit_dag(root, name="unnamed")
+
+    assert submitted[0].dag_run_id == dag_run_id
+
+
+@pytest.mark.asyncio
+async def test_submit_dag_honors_explicit_dag_run_id_override(state_manager):
+    """submit_dag uses a caller-supplied dag_run_id instead of self-generating one."""
+    root = DAGNode("fetch_data")
+    forced_id = ULID()
+
+    dag_run_id, submitted = await state_manager.submit_dag(root, name="forced", dag_run_id=forced_id)
+
+    assert dag_run_id == forced_id
+    assert submitted[0].dag_run_id == forced_id
 
 
 @pytest.mark.asyncio
@@ -1124,13 +1147,15 @@ async def test_submit_dag_multi_root_shares_dag_run_id(state_manager):
 
     state_manager.init_fan_in = AsyncMock()
 
-    dag_run_id, submitted = await state_manager.submit_dag(branch_a, branch_b)
+    dag_run_id, submitted = await state_manager.submit_dag(branch_a, branch_b, name="multi-root-run")
 
     assert dag_run_id is not None
     assert len(submitted) == 2
     assert submitted[0].dag_run_id is not None
     assert submitted[0].dag_run_id == submitted[1].dag_run_id
     assert submitted[0].dag_run_id == dag_run_id
+    assert submitted[0].dag_run_name == "multi-root-run"
+    assert submitted[1].dag_run_name == "multi-root-run"
 
 
 @pytest.mark.asyncio
@@ -1143,7 +1168,7 @@ async def test_submit_dag_fan_in_initialises_fan_in_sets(state_manager):
 
     state_manager.init_fan_in = AsyncMock()
 
-    dag_run_id, submitted = await state_manager.submit_dag(branch_a, branch_b)
+    dag_run_id, submitted = await state_manager.submit_dag(branch_a, branch_b, name="fan-in-run")
 
     # init_fan_in must be called with the run's dag_run_id and the collector's fan-in key
     fan_in_key = f"dag:fan-in:{collector.id}"

--- a/tests/test_state_manager.py
+++ b/tests/test_state_manager.py
@@ -547,6 +547,127 @@ async def test_sweep_dag_run_orphaned_index_no_fallback_task_is_noop(state_manag
     await state_manager_real_ta.sweep_dag_run(dag_run_id)
 
 
+# ── finalize_dag_run_task ───────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_finalize_dag_run_task_uses_pipelined_path_when_atomic_dag_run_available(state_manager_real_ta):
+    """
+    Sanity check for the fixture used by the tests below.
+
+    state_manager_real_ta's RedisTaskState implements AtomicDagRunProtocol, so
+    finalize_dag_run_task takes the pipelined record+close round trip.
+    """
+    assert state_manager_real_ta._atomic_dag_run is not None
+
+
+@pytest.mark.asyncio
+async def test_finalize_dag_run_task_completes_run_only_after_last_task(state_manager_real_ta):
+    """Pipelined path: a 2-task run reaches 'complete' only once both tasks have finalized."""
+    dag_run_id = ULID()
+    task_a = Task(
+        id=ULID1,
+        name="my_task",
+        version=1,
+        status=TaskStatus.COMPLETED,
+        queue="default",
+        dag_run_id=dag_run_id,
+        submitted_at=FROZEN_TIME,
+    )
+    task_b = Task(
+        id=ULID2,
+        name="my_task",
+        version=1,
+        status=TaskStatus.COMPLETED,
+        queue="default",
+        dag_run_id=dag_run_id,
+        submitted_at=FROZEN_TIME,
+    )
+    await state_manager_real_ta.task_submit.submit_task(task=task_a)
+    await state_manager_real_ta.task_submit.submit_task(task=task_b)
+
+    cleanup_config = TaskConfig(name="my_task", function=dummy_fn)
+    with patch.object(registry, "get_task_config", return_value=cleanup_config):
+        await state_manager_real_ta.finalize_dag_run_task(task_a)
+        run = await state_manager_real_ta.get_dag_run(dag_run_id)
+        assert run is not None
+        assert run.status.value == "running"
+
+        await state_manager_real_ta.finalize_dag_run_task(task_b)
+        run = await state_manager_real_ta.get_dag_run(dag_run_id)
+        assert run is not None
+        assert run.status.value == "complete"
+
+
+@pytest.mark.asyncio
+async def test_finalize_dag_run_task_stuck_status_records_but_never_closes(state_manager_real_ta):
+    """A FAILED task's outcome is recorded, but it never closes out of the pending set."""
+    dag_run_id = ULID()
+    task = Task(
+        id=ULID1,
+        name="my_task",
+        version=1,
+        status=TaskStatus.FAILED,
+        queue="default",
+        dag_run_id=dag_run_id,
+        submitted_at=FROZEN_TIME,
+    )
+    await state_manager_real_ta.task_submit.submit_task(task=task)
+
+    await state_manager_real_ta.finalize_dag_run_task(task)
+
+    run = await state_manager_real_ta.get_dag_run(dag_run_id)
+    assert run is not None
+    assert run.status.value == "failed"
+    # Never closed out of DAG_RUN_PENDING: close_dag_run_task still finds it pending.
+    assert await state_manager_real_ta.close_dag_run_task(dag_run_id, ULID1) == 0
+
+
+@pytest.mark.asyncio
+async def test_finalize_dag_run_task_sequential_fallback_matches_pipelined_result(state_manager_real_ta):
+    """
+    Sequential fallback (no AtomicDagRunProtocol) reaches the same end state as the pipelined path.
+
+    With _atomic_dag_run forced off, finalize_dag_run_task falls back to two
+    sequential calls: record_dag_run_task_terminal then close_dag_run_task_and_sweep.
+    """
+    state_manager_real_ta._atomic_dag_run = None
+
+    dag_run_id = ULID()
+    task_a = Task(
+        id=ULID1,
+        name="my_task",
+        version=1,
+        status=TaskStatus.COMPLETED,
+        queue="default",
+        dag_run_id=dag_run_id,
+        submitted_at=FROZEN_TIME,
+    )
+    task_b = Task(
+        id=ULID2,
+        name="my_task",
+        version=1,
+        status=TaskStatus.COMPLETED,
+        queue="default",
+        dag_run_id=dag_run_id,
+        submitted_at=FROZEN_TIME,
+    )
+    await state_manager_real_ta.task_submit.submit_task(task=task_a)
+    await state_manager_real_ta.task_submit.submit_task(task=task_b)
+
+    cleanup_config = TaskConfig(name="my_task", function=dummy_fn)
+    with patch.object(registry, "get_task_config", return_value=cleanup_config):
+        await state_manager_real_ta.finalize_dag_run_task(task_a)
+        run = await state_manager_real_ta.get_dag_run(dag_run_id)
+        assert run is not None
+        assert run.status.value == "running"
+
+        await state_manager_real_ta.finalize_dag_run_task(task_b)
+        run = await state_manager_real_ta.get_dag_run(dag_run_id)
+        assert run is not None
+        assert run.status.value == "complete"
+
+
 # ── fail_task ─────────────────────────────────────────────────────────────────
 
 

--- a/tests/test_task_processor.py
+++ b/tests/test_task_processor.py
@@ -2175,6 +2175,7 @@ async def test_maybe_cleanup_dag_task_delegates_to_state_manager():
 
     assert task.status == TaskStatus.COMPLETED
     state_manager.close_dag_run_task_and_sweep.assert_awaited_once_with(task)
+    state_manager.record_dag_run_task_terminal.assert_awaited_once_with(task)
     state_manager.delete_task.assert_not_awaited()
 
 
@@ -2220,6 +2221,7 @@ async def test_maybe_cleanup_skipped_for_non_terminal_status():
     # then queue_retry_task re-queues it as SUBMITTED — either way, not terminal.
     assert task.status == TaskStatus.SUBMITTED
     state_manager.close_dag_run_task_and_sweep.assert_not_awaited()
+    state_manager.record_dag_run_task_terminal.assert_not_awaited()
     state_manager.delete_task.assert_not_awaited()
 
 
@@ -2265,6 +2267,7 @@ async def test_maybe_cleanup_failed_dag_task_does_not_close_pending():
 
     assert task.status == TaskStatus.FAILED
     state_manager.close_dag_run_task_and_sweep.assert_not_awaited()
+    state_manager.record_dag_run_task_terminal.assert_awaited_once_with(task)
     state_manager.delete_task.assert_not_awaited()
 
 
@@ -2296,6 +2299,7 @@ async def test_maybe_cleanup_stuck_dag_task_does_not_close_pending(status):
     await processor._maybe_cleanup(task)
 
     state_manager.close_dag_run_task_and_sweep.assert_not_awaited()
+    state_manager.record_dag_run_task_terminal.assert_awaited_once_with(task)
 
 
 @pytest.mark.asyncio

--- a/tests/test_task_processor.py
+++ b/tests/test_task_processor.py
@@ -2140,11 +2140,13 @@ async def test_maybe_cleanup_standalone_no_cleanup_on():
 @pytest.mark.asyncio
 async def test_maybe_cleanup_dag_task_delegates_to_state_manager():
     """
-    DAG tasks delegate to StateManager.close_dag_run_task_and_sweep.
+    DAG tasks delegate to StateManager.finalize_dag_run_task.
 
-    The counter-close-and-sweep logic itself now lives on StateManager (so the
-    Cleaner's stale-heartbeat path can trigger it too, see test_state_manager.py) —
-    TaskProcessor just needs to call it exactly once per DAG-task completion.
+    All the DAG-run bookkeeping (aggregate-status recording, pending-counter close,
+    sibling sweep, and the ordering between them) now lives on StateManager behind
+    this single method — TaskProcessor just needs to call it exactly once per
+    DAG-task completion. See test_state_manager.py for coverage of what
+    finalize_dag_run_task itself does.
     """
     dag_run_id = ULID()
     task_id = ULID.from_str("01JQC31AJP7TSA9X8AEP64XG08")
@@ -2159,7 +2161,6 @@ async def test_maybe_cleanup_dag_task_delegates_to_state_manager():
     )
 
     state_manager = _make_state_manager()
-    state_manager.close_dag_run_task_and_sweep = AsyncMock()
 
     task_function = AsyncMock(return_value=None)
     task_config = TaskConfig(
@@ -2174,8 +2175,7 @@ async def test_maybe_cleanup_dag_task_delegates_to_state_manager():
         await processor.process(task)
 
     assert task.status == TaskStatus.COMPLETED
-    state_manager.close_dag_run_task_and_sweep.assert_awaited_once_with(task)
-    state_manager.record_dag_run_task_terminal.assert_awaited_once_with(task)
+    state_manager.finalize_dag_run_task.assert_awaited_once_with(task)
     state_manager.delete_task.assert_not_awaited()
 
 
@@ -2211,7 +2211,6 @@ async def test_maybe_cleanup_skipped_for_non_terminal_status():
     )
 
     state_manager = _make_state_manager()
-    state_manager.close_dag_run_task_and_sweep = AsyncMock()
 
     with patch("jobbers.task_processor.get_task_config", return_value=task_config):
         processor = TaskProcessor(state_manager)
@@ -2220,8 +2219,7 @@ async def test_maybe_cleanup_skipped_for_non_terminal_status():
     # No retry_delay configured means immediate retry: _handle_retry sets UNSUBMITTED,
     # then queue_retry_task re-queues it as SUBMITTED — either way, not terminal.
     assert task.status == TaskStatus.SUBMITTED
-    state_manager.close_dag_run_task_and_sweep.assert_not_awaited()
-    state_manager.record_dag_run_task_terminal.assert_not_awaited()
+    state_manager.finalize_dag_run_task.assert_not_awaited()
     state_manager.delete_task.assert_not_awaited()
 
 
@@ -2259,15 +2257,13 @@ async def test_maybe_cleanup_failed_dag_task_does_not_close_pending():
     )
 
     state_manager = _make_state_manager()
-    state_manager.close_dag_run_task_and_sweep = AsyncMock()
 
     with patch("jobbers.task_processor.get_task_config", return_value=task_config):
         processor = TaskProcessor(state_manager)
         await processor.process(task)
 
     assert task.status == TaskStatus.FAILED
-    state_manager.close_dag_run_task_and_sweep.assert_not_awaited()
-    state_manager.record_dag_run_task_terminal.assert_awaited_once_with(task)
+    state_manager.finalize_dag_run_task.assert_awaited_once_with(task)
     state_manager.delete_task.assert_not_awaited()
 
 
@@ -2293,13 +2289,11 @@ async def test_maybe_cleanup_stuck_dag_task_does_not_close_pending(status):
         dag_run_id=dag_run_id,
     )
     state_manager = _make_state_manager()
-    state_manager.close_dag_run_task_and_sweep = AsyncMock()
 
     processor = TaskProcessor(state_manager)
     await processor._maybe_cleanup(task)
 
-    state_manager.close_dag_run_task_and_sweep.assert_not_awaited()
-    state_manager.record_dag_run_task_terminal.assert_awaited_once_with(task)
+    state_manager.finalize_dag_run_task.assert_awaited_once_with(task)
 
 
 @pytest.mark.asyncio
@@ -2339,7 +2333,6 @@ async def test_maybe_cleanup_runs_after_dynamic_fanout_registers_arms():
 
     state_manager = _make_state_manager()
     state_manager.get_queue_config = AsyncMock(return_value=None)
-    state_manager.close_dag_run_task_and_sweep = AsyncMock()
 
     with patch("jobbers.task_processor.get_task_config", return_value=task_config):
         processor = TaskProcessor(state_manager)
@@ -2348,5 +2341,5 @@ async def test_maybe_cleanup_runs_after_dynamic_fanout_registers_arms():
     assert task.status == TaskStatus.COMPLETED
     call_names = [c[0] for c in state_manager.mock_calls]
     submit_index = call_names.index("submit_tasks_batch")
-    close_index = call_names.index("close_dag_run_task_and_sweep")
+    close_index = call_names.index("finalize_dag_run_task")
     assert submit_index < close_index, "arms must be registered before the dispatcher closes out of the run"

--- a/tests/test_task_routes.py
+++ b/tests/test_task_routes.py
@@ -9,7 +9,7 @@ from sqlalchemy.exc import IntegrityError
 from ulid import ULID
 
 from jobbers.adapters.sql import SQLQueueConfigAdapter
-from jobbers.models.dag import DAGRunPagination
+from jobbers.models.dag import DAGRunDetail, DAGRunPagination, DagRunStatus, DAGRunSummary
 from jobbers.models.queue_config import QueueConfig
 from jobbers.models.task import Task
 from jobbers.models.task_config import TaskConfig
@@ -1119,8 +1119,11 @@ async def test_list_dags_empty(state_manager):
 
 @pytest.mark.asyncio
 async def test_list_dags_returns_runs(state_manager):
-    """GET /dags returns DAG runs with dag_run_id and submitted_at."""
-    state_manager.list_dag_runs = AsyncMock(return_value=([(DAG_RUN_ID, SUBMITTED_AT)], 1))
+    """GET /dags returns DAG runs with dag_run_id, name, status, and submitted_at."""
+    run = DAGRunSummary(
+        dag_run_id=DAG_RUN_ID, name="my-run", status=DagRunStatus.RUNNING, submitted_at=SUBMITTED_AT
+    )
+    state_manager.list_dag_runs = AsyncMock(return_value=([run], 1))
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         response = await client.get("/dags")
@@ -1130,6 +1133,8 @@ async def test_list_dags_returns_runs(state_manager):
     assert data["total"] == 1
     assert len(data["dags"]) == 1
     assert data["dags"][0]["dag_run_id"] == str(DAG_RUN_ID)
+    assert data["dags"][0]["name"] == "my-run"
+    assert data["dags"][0]["status"] == "running"
     assert data["dags"][0]["submitted_at"] == SUBMITTED_AT.isoformat()
 
 
@@ -1147,8 +1152,15 @@ async def test_list_dags_passes_pagination(state_manager):
 
 @pytest.mark.asyncio
 async def test_get_dag_found(state_manager):
-    """GET /dags/{dag_run_id} returns run details and task IDs."""
-    state_manager.get_dag_run = AsyncMock(return_value=(SUBMITTED_AT, [ULID1, ULID2]))
+    """GET /dags/{dag_run_id} returns run details, name, status, and task IDs."""
+    detail = DAGRunDetail(
+        dag_run_id=DAG_RUN_ID,
+        name="my-run",
+        status=DagRunStatus.PARTIAL_FAILURE,
+        submitted_at=SUBMITTED_AT,
+        task_ids=[ULID1, ULID2],
+    )
+    state_manager.get_dag_run = AsyncMock(return_value=detail)
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         response = await client.get(f"/dags/{DAG_RUN_ID}")
@@ -1156,6 +1168,8 @@ async def test_get_dag_found(state_manager):
     assert response.status_code == 200
     data = response.json()
     assert data["dag_run_id"] == str(DAG_RUN_ID)
+    assert data["name"] == "my-run"
+    assert data["status"] == "partial_failure"
     assert data["submitted_at"] == SUBMITTED_AT.isoformat()
     assert data["task_ids"] == [str(ULID1), str(ULID2)]
 
@@ -1444,6 +1458,36 @@ async def test_submit_dag_raises_429_on_rate_limited_error():
 
     assert response.status_code == 429
     assert "queue is full" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_submit_dag_defaults_name_to_dag_run_id():
+    """POST /submit-dag with no name field succeeds; the run's name defaults to its dag_run_id."""
+    diagram = 'flowchart TD\n  A["my_task@1"]'
+
+    async def task_function(**kwargs: object) -> None: ...
+
+    test_task_config = TaskConfig(name="my_task", version=1, function=task_function)
+    captured: dict[str, object] = {}
+
+    async def fake_submit_dag(*roots: object, name: str, dag_run_id: ULID | None = None) -> tuple[ULID, list]:
+        captured["name"] = name
+        captured["dag_run_id"] = dag_run_id
+        return dag_run_id, []
+
+    mock_sm = MagicMock()
+    mock_sm.submit_dag = AsyncMock(side_effect=fake_submit_dag)
+
+    with (
+        patch("jobbers.task_routes.db.get_state_manager", return_value=mock_sm),
+        patch("jobbers.registry.get_task_config", return_value=test_task_config),
+    ):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            response = await client.post("/submit-dag", json={"diagram": diagram})
+
+    assert response.status_code == 200
+    assert response.json()["dag_run_id"] == str(captured["dag_run_id"])
+    assert captured["name"] == str(captured["dag_run_id"])
 
 
 # ── PUT /cron-dags/{id} branches ─────────────────────────────────────────────


### PR DESCRIPTION
Introduce a name for DAG runs and an aggregate status field to enhance tracking and visibility. Update the API to expose these new attributes and modify the DAG list and detail views to display them. Adjust related tests to ensure proper functionality.